### PR TITLE
feat: implement envelope encryption for media files

### DIFF
--- a/.kiro/specs/cortex/tasks.md
+++ b/.kiro/specs/cortex/tasks.md
@@ -209,8 +209,8 @@
   - **Property 27: Vault salt uniqueness**
   - **Validates: Requirements 22.4**
 
-- [ ] 6.12 Implement envelope encryption for media files
-  - [ ] 6.12.1 Create DEK generation and wrapping functions with key commitment documentation and binary format
+- [x] 6.12 Implement envelope encryption for media files
+  - [x] 6.12.1 Create DEK generation and wrapping functions with key commitment documentation and binary format
     - Add to packages/encryption/src/lib/envelope-encryption.ts
     - Generate unique 256-bit DEK per file using CSPRNG
     - Wrap DEK with KEK using ChaCha20-Poly1305
@@ -228,14 +228,14 @@
     - Export functions: generateDek(), wrapDek(dek, kek, fileId?, includeBinding?), unwrapDek(wrappedDek, kek)
     - _Requirements: 28.1, 28.2, 28.3, 28.4, 28.5, 28.6, 28.7, 28.8, 28.9, 28.10, 28.11, 28.12_
 
-  - [ ] 6.12.2 Create file encryption with DEK
+  - [x] 6.12.2 Create file encryption with DEK
     - Add to packages/encryption/src/lib/envelope-encryption.ts
     - Encrypt file content with DEK using ChaCha20-Poly1305
     - Return encrypted content and wrapped DEK
     - Export function: encryptFileWithDek(content, kek)
     - _Requirements: 28.2, 28.3_
 
-  - [ ] 6.12.3 Create file decryption with DEK and error handling
+  - [x] 6.12.3 Create file decryption with DEK and error handling
     - Add to packages/encryption/src/lib/envelope-encryption.ts
     - Unwrap DEK using KEK with error handling
     - Return specific error codes for failure types:
@@ -252,12 +252,12 @@
     - Export error types: DekUnwrapError { code: 'CORRUPTED_DEK' | 'WRONG_KEK_VERSION' | 'AUTHENTICATION_FAILED', message: string }
     - _Requirements: 29.2, 29.3, 29.4, 29.5, 29.6, 29.7, 29.8, 29.9, 29.10, 29.11_
 
-  - [ ]* 6.12.4 Write property test for envelope encryption round-trip
+  - [x]* 6.12.4 Write property test for envelope encryption round-trip
     - Create packages/encryption/tests/property/test_envelope_encryption.test.ts
     - **Property 32: Envelope encryption round-trip**
     - **Validates: Requirements 28.1, 28.2, 28.3, 29.2, 29.3**
 
-  - [ ]* 6.12.5 Write property test for DEK uniqueness
+  - [x]* 6.12.5 Write property test for DEK uniqueness
     - Add to packages/encryption/tests/property/test_envelope_encryption.test.ts
     - **Property 33: DEK uniqueness**
     - **Validates: Requirements 28.4, 28.5**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,9 +32,15 @@ Cortex is a privacy-first photo and video backup solution where all encryption h
 - HKDF derives multiple keys from vault master key: KEK (Key Encryption Key), metadata encryption key, share key derivation key
 
 **Envelope Encryption (Media Files):**
-- Each media file encrypted with unique DEK (Data Encryption Key)
+- Each media file encrypted with unique DEK (Data Encryption Key) via ChaCha20-Poly1305
 - DEK wrapped with vault's KEK and stored in DynamoDB (not S3)
+- Wrapped DEK binary format: `[version(1)][timestamp(4)][nonce(12)][encryptedDEK(32)][authTag(16)]` = 65 bytes
+- Optional HMAC-SHA256 binding: appends 32-byte `HMAC(DEK, fileId)` for key substitution defense (97 bytes total)
 - File content encrypted with DEK, uploaded to S3
+- Implementation: `packages/encryption/src/lib/envelope-encryption.ts`
+- API: `generateDek()`, `wrapDek()`, `unwrapDek()`, `encryptFileWithDek()`, `decryptFileWithDek()`
+- Error type: `DekUnwrapError` with codes `CORRUPTED_DEK`, `WRONG_KEK_VERSION`, `AUTHENTICATION_FAILED`
+- DEK zeroed after use in `encryptFileWithDek` and `decryptFileWithDek` (try/finally)
 - Benefits:
   - Efficient key rotation: only re-wrap DEKs, not re-encrypt files
   - Fast sharing: wrap DEK with share key, no file re-upload
@@ -216,7 +222,9 @@ cortex/
 │   │   ├── src/
 │   │   │   ├── lib/
 │   │   │   │   ├── encryption.ts     # ChaCha20-Poly1305
+│   │   │   │   ├── envelope-encryption.ts # DEK generation, wrapping, file encryption
 │   │   │   │   ├── key-management.ts # Argon2id, HKDF
+│   │   │   │   ├── key-storage.ts    # IndexedDB + Web Crypto key storage
 │   │   │   │   ├── password-validation.ts
 │   │   │   │   └── sharing.ts
 │   │   │   └── index.ts

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ cortex/
 │   └── tests/             # Unit, integration, and property tests
 ├── packages/              # Monorepo packages (npm workspaces)
 │   ├── encryption/        # @cortex/encryption - Standalone encryption library
-│   │   ├── src/lib/       # encryption, key-management, key-storage, password-validation
+│   │   ├── src/lib/       # encryption, envelope-encryption, key-management, key-storage, password-validation
 │   │   └── tests/         # Unit and property tests
 │   └── web/               # @cortex/web - React web application
 │       └── src/           # App.tsx, main.tsx
@@ -104,7 +104,8 @@ npm test
 3. **Vault Password**: Derives encryption keys (never transmitted to server)
 4. **Vault Salt**: Stored on server (non-secret), enables multi-device key derivation
 5. **Vault Master Key**: Derived from vault password + salt using Argon2id
-6. **Derived Keys**: Data encryption key, metadata encryption key, share key derivation key
+6. **Derived Keys**: KEK (Key Encryption Key), metadata encryption key, share key derivation key
+7. **Envelope Encryption**: Each media file encrypted with a unique DEK, DEK wrapped with KEK
 
 **Recovery Options:**
 - **Account Recovery**: Use one of 10 recovery codes to reset account password (codes are hashed with SHA-256 and invalidated after use)
@@ -119,7 +120,7 @@ npm test
 - **Item Management**: Create, upload, list, retrieve, update, delete items (MEDIA, NOTE, TASK, EVENT types)
 - **Collection Management**: Create, list, retrieve, update, delete collections with many-to-many item associations
 - **Tag Search**: Search items by encrypted tags with vault isolation and pagination
-- **Encryption Library**: ChaCha20-Poly1305 encryption, Argon2id key derivation, password validation
+- **Encryption Library**: ChaCha20-Poly1305 encryption, envelope encryption (DEK/KEK), Argon2id key derivation, password validation
 - **API Layer**: Single Lambda function with APIGatewayRestResolver handling all routes
 - **Testing**: Unit tests with botocore Stubber, property-based tests with Hypothesis
 

--- a/docs/plans/2026-02-05-envelope-encryption-design.md
+++ b/docs/plans/2026-02-05-envelope-encryption-design.md
@@ -1,0 +1,151 @@
+# Envelope Encryption for Media Files — Design
+
+Task 6.12 and subtasks 6.12.1–6.12.5.
+
+## Overview
+
+Each media file gets a unique Data Encryption Key (DEK). The DEK encrypts the file content, then the DEK itself is wrapped (encrypted) with the vault's Key Encryption Key (KEK). This means key rotation only requires re-wrapping DEKs — not re-encrypting every file.
+
+## Binary Format
+
+### Wrapped DEK without HMAC binding (65 bytes)
+
+| Offset | Size | Field |
+|--------|------|-------|
+| 0 | 1 | Version (`0x01`) |
+| 1 | 4 | Timestamp (uint32_be, Unix epoch seconds) |
+| 5 | 12 | Nonce (ChaCha20-Poly1305) |
+| 17 | 32 | Encrypted DEK |
+| 49 | 16 | Auth tag |
+
+### Wrapped DEK with HMAC binding (97 bytes)
+
+Same as above, plus:
+
+| Offset | Size | Field |
+|--------|------|-------|
+| 65 | 32 | HMAC-SHA256(DEK, file_id) |
+
+Detection: buffer length of 97 indicates HMAC binding is present; 65 indicates no binding. Version byte is `0x01` for both variants.
+
+## Exported API
+
+File: `packages/encryption/src/lib/envelope-encryption.ts`
+
+### Types
+
+```typescript
+export type DekUnwrapErrorCode =
+  | 'CORRUPTED_DEK'
+  | 'WRONG_KEK_VERSION'
+  | 'AUTHENTICATION_FAILED';
+
+export class DekUnwrapError extends Error {
+  constructor(
+    public readonly code: DekUnwrapErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = 'DekUnwrapError';
+  }
+}
+```
+
+### Functions
+
+```typescript
+generateDek(): Promise<Uint8Array>
+```
+Returns 32 random bytes via CSPRNG.
+
+```typescript
+wrapDek(dek: Uint8Array, kek: Uint8Array, fileId?: string): Promise<Uint8Array>
+```
+Encrypts DEK with KEK using ChaCha20-Poly1305, packs into binary format. If `fileId` is provided, appends HMAC-SHA256(DEK, fileId) for binding. Returns 65 or 97 bytes.
+
+```typescript
+unwrapDek(wrappedDek: Uint8Array, kek: Uint8Array, fileId?: string): Uint8Array
+```
+Parses binary format, decrypts DEK, verifies HMAC if present. Throws `DekUnwrapError` on failure.
+
+```typescript
+encryptFileWithDek(
+  content: Uint8Array,
+  kek: Uint8Array,
+  fileId?: string
+): Promise<{ encryptedContent: Uint8Array; wrappedDek: Uint8Array }>
+```
+Generates a DEK, encrypts content, wraps DEK, zeros DEK buffer, returns both.
+
+```typescript
+decryptFileWithDek(
+  encryptedContent: Uint8Array,
+  wrappedDek: Uint8Array,
+  kek: Uint8Array,
+  fileId?: string
+): Uint8Array
+```
+Unwraps DEK, decrypts content, zeros DEK buffer, returns plaintext. Throws `DekUnwrapError` on failure.
+
+## Error Handling
+
+`unwrapDek` validation order:
+
+1. **Structural validation** (before any crypto):
+   - Length must be 65 or 97 → `CORRUPTED_DEK`
+   - Version byte must be `0x01` → `WRONG_KEK_VERSION`
+
+2. **ChaCha20-Poly1305 decryption**:
+   - Auth tag failure → `AUTHENTICATION_FAILED`
+
+3. **HMAC verification** (if binding present):
+   - Requires `fileId` parameter → `CORRUPTED_DEK` if missing
+   - Computes HMAC-SHA256(decrypted DEK, fileId), compares to stored HMAC
+   - Mismatch → `CORRUPTED_DEK` (zeros DEK before throwing)
+
+HMAC verification happens after decryption because the HMAC is computed over the plaintext DEK.
+
+## Security
+
+- **DEK zeroing**: `dek.fill(0)` after use in `encryptFileWithDek` and `decryptFileWithDek`, and in error paths where DEK was decrypted but HMAC fails.
+- **Uint8Array only**: All key material uses `Uint8Array` to enable explicit zeroing.
+- **No key material in errors**: Error messages contain only error codes and descriptions.
+- **Failure logging**: `console.warn` with error code and timestamp, no key material.
+
+### Key Commitment Documentation
+
+JSDoc on `wrapDek` will document:
+1. ChaCha20-Poly1305 does not provide key commitment — an attacker could theoretically find two DEKs that both decrypt to valid plaintexts.
+2. Risk is low in Cortex because an attacker must replace both the ciphertext AND the wrapped DEK.
+3. HMAC binding (when `fileId` provided) adds defense-in-depth against key substitution.
+
+## Property Tests
+
+File: `packages/encryption/tests/property/test_envelope_encryption.test.ts`
+
+### Property 32 — Envelope encryption round-trip
+
+For random content (0–10KB), random 32-byte KEK, and optional fileId:
+- `encryptFileWithDek` then `decryptFileWithDek` returns original content
+- Encrypted content differs from plaintext
+- Wrapped DEK is 65 bytes (no fileId) or 97 bytes (with fileId)
+- Version byte is `0x01`
+
+Validates: 28.1, 28.2, 28.3, 29.2, 29.3
+
+### Property 33 — DEK uniqueness
+
+- 100 calls to `generateDek()` produce 100 unique 32-byte keys
+- Two files encrypted with the same KEK produce different wrapped DEKs
+
+Validates: 28.4, 28.5
+
+## Implementation Order
+
+1. 6.12.1 — `generateDek`, `wrapDek`, `unwrapDek`, `DekUnwrapError`
+2. 6.12.2 — `encryptFileWithDek`
+3. 6.12.3 — `decryptFileWithDek` with error handling and DEK zeroing
+4. 6.12.4 — Property 32 (round-trip)
+5. 6.12.5 — Property 33 (uniqueness)
+
+Each subtask builds on the previous. Export all public API from `packages/encryption/src/index.ts`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1168,34 +1168,6 @@
         }
       }
     },
-    "node_modules/@jest/core/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@jest/core/node_modules/pretty-format": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.0.5",
-        "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/@jest/diff-sequences": {
       "version": "30.0.1",
       "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
@@ -2105,169 +2077,14 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.5.14",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
-      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "expect": "^29.0.0",
-        "pretty-format": "^29.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/@jest/expect-utils": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
-      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jest-get-type": "^29.6.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
-      "version": "0.27.8",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/jest/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@types/jest/node_modules/expect": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
-      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/expect-utils": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-diff": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^29.6.3",
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-matcher-utils": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
-      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "jest-diff": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-message-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.6.3",
-        "@types/stack-utils": "^2.0.0",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^29.7.0",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
       }
     },
     "node_modules/@types/node": {
@@ -3326,16 +3143,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/diff-sequences": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -4048,34 +3855,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-circus/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-circus/node_modules/pretty-format": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.0.5",
-        "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/jest-cli": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.2.0.tgz",
@@ -4161,34 +3940,6 @@
         }
       }
     },
-    "node_modules/jest-config/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-config/node_modules/pretty-format": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.0.5",
-        "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/jest-diff": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
@@ -4200,34 +3951,6 @@
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
         "pretty-format": "30.2.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-diff/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-diff/node_modules/pretty-format": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.0.5",
-        "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -4263,34 +3986,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-each/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-each/node_modules/pretty-format": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.0.5",
-        "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/jest-environment-node": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.2.0.tgz",
@@ -4308,16 +4003,6 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-get-type": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
-      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-haste-map": {
@@ -4359,34 +4044,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-leak-detector/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-leak-detector/node_modules/pretty-format": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.0.5",
-        "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/jest-matcher-utils": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.2.0.tgz",
@@ -4398,34 +4055,6 @@
         "chalk": "^4.1.2",
         "jest-diff": "30.2.0",
         "pretty-format": "30.2.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/pretty-format": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.0.5",
-        "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -4447,34 +4076,6 @@
         "pretty-format": "30.2.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.6"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/pretty-format": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.0.5",
-        "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -4658,34 +4259,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/pretty-format": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.0.5",
-        "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/jest-snapshot/node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -4748,19 +4321,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-validate/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/jest-validate/node_modules/camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -4772,21 +4332,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/jest-validate/node_modules/pretty-format": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.0.5",
-        "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-watcher": {
@@ -5411,39 +4956,19 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
-    },
-    "node_modules/pretty-format/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/@sinclair/typebox": {
-      "version": "0.27.8",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
@@ -6789,7 +6314,7 @@
       },
       "devDependencies": {
         "@fast-check/jest": "^2.1.1",
-        "@types/jest": "^29.5.14",
+        "@types/jest": "^30.0.0",
         "@types/node": "^20.0.0",
         "jest": "^30.2.0",
         "ts-jest": "^29.4.6",

--- a/packages/README.md
+++ b/packages/README.md
@@ -10,6 +10,7 @@ Standalone zero-knowledge encryption library for Cortex. This package provides a
 
 **Features:**
 - ChaCha20-Poly1305 authenticated encryption
+- Envelope encryption (per-file DEK wrapped with KEK)
 - Argon2id key derivation
 - HKDF key expansion
 - Password validation and breach checking

--- a/packages/encryption/src/index.ts
+++ b/packages/encryption/src/index.ts
@@ -51,3 +51,14 @@ export {
   checkPasswordBreach,
   type PasswordValidationResult,
 } from './lib/password-validation';
+
+// Export envelope encryption functions
+export {
+  generateDek,
+  wrapDek,
+  unwrapDek,
+  encryptFileWithDek,
+  decryptFileWithDek,
+  DekUnwrapError,
+  type DekUnwrapErrorCode,
+} from './lib/envelope-encryption';

--- a/packages/encryption/src/lib/envelope-encryption.ts
+++ b/packages/encryption/src/lib/envelope-encryption.ts
@@ -1,0 +1,303 @@
+/**
+ * Envelope Encryption for Media Files
+ *
+ * Each media file gets a unique Data Encryption Key (DEK). The DEK encrypts
+ * the file content, then the DEK itself is wrapped (encrypted) with the vault's
+ * Key Encryption Key (KEK). Key rotation only requires re-wrapping DEKs —
+ * not re-encrypting every file.
+ *
+ * Binary format for wrapped DEK (65 bytes without HMAC, 97 bytes with):
+ *   [version(1)][timestamp(4)][nonce(12)][encryptedDEK(32)][authTag(16)]
+ *   Optional: [HMAC-SHA256(DEK, fileId)(32)]
+ *
+ * Requirements: 28.1–28.5, 29.2, 29.3
+ */
+
+import { chacha20poly1305 } from '@noble/ciphers/chacha';
+import { hmac } from '@noble/hashes/hmac';
+import { sha256 } from '@noble/hashes/sha2';
+
+const WRAPPED_DEK_SIZE = 65;
+const WRAPPED_DEK_WITH_HMAC_SIZE = 97;
+const VERSION = 0x01;
+const DEK_SIZE = 32;
+const NONCE_SIZE = 12;
+const TIMESTAMP_SIZE = 4;
+const AUTH_TAG_SIZE = 16;
+
+// Use Web Crypto API for random bytes generation
+const getRandomBytes = async (size: number): Promise<Uint8Array> => {
+  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+    return crypto.getRandomValues(new Uint8Array(size));
+  }
+  try {
+    const { randomBytes } = await import('node:crypto');
+    return new Uint8Array(randomBytes(size));
+  } catch {
+    throw new Error('No secure random number generator available');
+  }
+};
+
+// --- Error types ---
+
+export type DekUnwrapErrorCode =
+  | 'CORRUPTED_DEK'
+  | 'WRONG_KEK_VERSION'
+  | 'AUTHENTICATION_FAILED';
+
+export class DekUnwrapError extends Error {
+  constructor(
+    public readonly code: DekUnwrapErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = 'DekUnwrapError';
+  }
+}
+
+// --- Core functions ---
+
+/**
+ * Generate a random 32-byte Data Encryption Key via CSPRNG.
+ */
+export async function generateDek(): Promise<Uint8Array> {
+  return await getRandomBytes(DEK_SIZE);
+}
+
+/**
+ * Wrap (encrypt) a DEK with a KEK using ChaCha20-Poly1305.
+ *
+ * Returns a 65-byte buffer (no fileId) or 97-byte buffer (with fileId).
+ *
+ * **Key commitment note:** ChaCha20-Poly1305 does not provide key commitment —
+ * an attacker could theoretically find two DEKs that both decrypt to valid
+ * plaintexts. Risk is low in Cortex because an attacker must replace both the
+ * ciphertext AND the wrapped DEK. HMAC binding (when `fileId` provided) adds
+ * defense-in-depth against key substitution.
+ *
+ * **Caller responsibility:** The caller must zero the DEK after use.
+ * This function does not zero the DEK because the caller may need it
+ * for further operations (e.g., encrypting file content).
+ *
+ * @param dek - The 32-byte Data Encryption Key to wrap
+ * @param kek - The 32-byte Key Encryption Key
+ * @param fileId - Optional file ID for HMAC binding
+ * @returns Wrapped DEK in binary format
+ */
+export async function wrapDek(
+  dek: Uint8Array,
+  kek: Uint8Array,
+  fileId?: string
+): Promise<Uint8Array> {
+  if (dek.length !== DEK_SIZE) {
+    throw new Error(`Invalid DEK size: expected ${DEK_SIZE} bytes, got ${dek.length} bytes`);
+  }
+  if (kek.length !== DEK_SIZE) {
+    throw new Error(`Invalid KEK size: expected ${DEK_SIZE} bytes, got ${kek.length} bytes`);
+  }
+
+  const nonce = await getRandomBytes(NONCE_SIZE);
+  const timestamp = Math.floor(Date.now() / 1000);
+
+  const cipher = chacha20poly1305(kek, nonce);
+  const encrypted = cipher.encrypt(dek);
+  // encrypted = encryptedDEK(32) + authTag(16) = 48 bytes
+
+  const hasHmac = fileId !== undefined && fileId !== null;
+  const totalSize = hasHmac ? WRAPPED_DEK_WITH_HMAC_SIZE : WRAPPED_DEK_SIZE;
+  const result = new Uint8Array(totalSize);
+
+  let offset = 0;
+
+  // Version byte
+  result[offset] = VERSION;
+  offset += 1;
+
+  // Timestamp (uint32_be)
+  result[offset] = (timestamp >>> 24) & 0xff;
+  result[offset + 1] = (timestamp >>> 16) & 0xff;
+  result[offset + 2] = (timestamp >>> 8) & 0xff;
+  result[offset + 3] = timestamp & 0xff;
+  offset += TIMESTAMP_SIZE;
+
+  // Nonce
+  result.set(nonce, offset);
+  offset += NONCE_SIZE;
+
+  // Encrypted DEK + auth tag
+  result.set(encrypted, offset);
+  offset += encrypted.length; // 32 + 16 = 48
+
+  // HMAC binding
+  if (hasHmac) {
+    const fileIdBytes = new TextEncoder().encode(fileId);
+    const hmacValue = hmac(sha256, dek, fileIdBytes);
+    result.set(hmacValue, offset);
+  }
+
+  return result;
+}
+
+/**
+ * Unwrap (decrypt) a wrapped DEK using a KEK.
+ *
+ * Validation order:
+ * 1. Structural validation (length, version) — before any crypto
+ * 2. ChaCha20-Poly1305 decryption — auth tag failure
+ * 3. HMAC verification (if binding present) — requires fileId
+ *
+ * @param wrappedDek - The wrapped DEK in binary format (65 or 97 bytes)
+ * @param kek - The 32-byte Key Encryption Key
+ * @param fileId - Optional file ID for HMAC verification
+ * @returns The unwrapped 32-byte DEK
+ * @throws DekUnwrapError on failure
+ */
+export function unwrapDek(
+  wrappedDek: Uint8Array,
+  kek: Uint8Array,
+  fileId?: string
+): Uint8Array {
+  // 0. Key size validation
+  if (kek.length !== DEK_SIZE) {
+    throw new Error(`Invalid KEK size: expected ${DEK_SIZE} bytes, got ${kek.length} bytes`);
+  }
+
+  // 1. Structural validation
+  if (wrappedDek.length !== WRAPPED_DEK_SIZE && wrappedDek.length !== WRAPPED_DEK_WITH_HMAC_SIZE) {
+    console.warn(`[envelope-encryption] CORRUPTED_DEK: invalid length ${wrappedDek.length} at ${new Date().toISOString()}`);
+    throw new DekUnwrapError('CORRUPTED_DEK', `Invalid wrapped DEK length: expected ${WRAPPED_DEK_SIZE} or ${WRAPPED_DEK_WITH_HMAC_SIZE} bytes, got ${wrappedDek.length}`);
+  }
+
+  if (wrappedDek[0] !== VERSION) {
+    console.warn(`[envelope-encryption] WRONG_KEK_VERSION: version ${wrappedDek[0]} at ${new Date().toISOString()}`);
+    throw new DekUnwrapError('WRONG_KEK_VERSION', `Unsupported wrapped DEK version: ${wrappedDek[0]}`);
+  }
+
+  // 2. ChaCha20-Poly1305 decryption
+  let offset = 1 + TIMESTAMP_SIZE; // skip version + timestamp
+  const nonce = wrappedDek.slice(offset, offset + NONCE_SIZE);
+  offset += NONCE_SIZE;
+  const encryptedWithTag = wrappedDek.slice(offset, offset + DEK_SIZE + AUTH_TAG_SIZE);
+
+  let dek: Uint8Array;
+  try {
+    const cipher = chacha20poly1305(kek, nonce);
+    dek = cipher.decrypt(encryptedWithTag);
+  } catch {
+    console.warn(`[envelope-encryption] AUTHENTICATION_FAILED at ${new Date().toISOString()}`);
+    throw new DekUnwrapError('AUTHENTICATION_FAILED', 'ChaCha20-Poly1305 authentication failed');
+  }
+
+  // 3. HMAC verification (if binding present)
+  const hasHmac = wrappedDek.length === WRAPPED_DEK_WITH_HMAC_SIZE;
+  if (hasHmac) {
+    if (fileId === undefined || fileId === null) {
+      dek.fill(0);
+      console.warn(`[envelope-encryption] CORRUPTED_DEK: HMAC binding present but no fileId at ${new Date().toISOString()}`);
+      throw new DekUnwrapError('CORRUPTED_DEK', 'Wrapped DEK has HMAC binding but no fileId was provided');
+    }
+
+    const storedHmac = wrappedDek.slice(WRAPPED_DEK_SIZE);
+    const fileIdBytes = new TextEncoder().encode(fileId);
+    // HMAC argument order: key=DEK (secret), message=fileId (identity being bound)
+    const computedHmac = hmac(sha256, dek, fileIdBytes);
+
+    // Constant-time comparison with defensive length check
+    if (storedHmac.length !== computedHmac.length) {
+      dek.fill(0);
+      console.warn(`[envelope-encryption] CORRUPTED_DEK: HMAC length mismatch at ${new Date().toISOString()}`);
+      throw new DekUnwrapError('CORRUPTED_DEK', 'HMAC binding verification failed');
+    }
+    let diff = 0;
+    for (let i = 0; i < computedHmac.length; i++) {
+      diff |= computedHmac[i] ^ storedHmac[i];
+    }
+
+    if (diff !== 0) {
+      dek.fill(0);
+      console.warn(`[envelope-encryption] CORRUPTED_DEK: HMAC mismatch at ${new Date().toISOString()}`);
+      throw new DekUnwrapError('CORRUPTED_DEK', 'HMAC binding verification failed');
+    }
+  }
+
+  return dek;
+}
+
+// --- File-level convenience functions ---
+
+/**
+ * Encrypt file content using envelope encryption.
+ *
+ * Generates a unique DEK, encrypts content, wraps the DEK with KEK,
+ * then zeros the DEK buffer.
+ *
+ * @param content - The file content to encrypt
+ * @param kek - The 32-byte Key Encryption Key
+ * @param fileId - Optional file ID for HMAC binding
+ * @returns The encrypted content and wrapped DEK
+ */
+export async function encryptFileWithDek(
+  content: Uint8Array,
+  kek: Uint8Array,
+  fileId?: string
+): Promise<{ encryptedContent: Uint8Array; wrappedDek: Uint8Array }> {
+  const dek = await generateDek();
+
+  try {
+    // Encrypt content with DEK using ChaCha20-Poly1305
+    const nonce = await getRandomBytes(NONCE_SIZE);
+    const cipher = chacha20poly1305(dek, nonce);
+    const ciphertext = cipher.encrypt(content);
+
+    // Format: [nonce][ciphertext with tag]
+    const encryptedContent = new Uint8Array(NONCE_SIZE + ciphertext.length);
+    encryptedContent.set(nonce, 0);
+    encryptedContent.set(ciphertext, NONCE_SIZE);
+
+    // Wrap the DEK with KEK
+    const wrappedDek = await wrapDek(dek, kek, fileId);
+
+    return { encryptedContent, wrappedDek };
+  } finally {
+    dek.fill(0);
+  }
+}
+
+/**
+ * Decrypt file content using envelope encryption.
+ *
+ * Unwraps the DEK, decrypts content, then zeros the DEK buffer.
+ *
+ * @param encryptedContent - The encrypted file content
+ * @param wrappedDek - The wrapped DEK
+ * @param kek - The 32-byte Key Encryption Key
+ * @param fileId - Optional file ID for HMAC verification
+ * @returns The decrypted file content
+ * @throws DekUnwrapError if DEK unwrapping fails
+ */
+export function decryptFileWithDek(
+  encryptedContent: Uint8Array,
+  wrappedDek: Uint8Array,
+  kek: Uint8Array,
+  fileId?: string
+): Uint8Array {
+  // Validate minimum encrypted content length: nonce + auth tag
+  if (encryptedContent.length < NONCE_SIZE + AUTH_TAG_SIZE) {
+    throw new Error(
+      `Invalid encrypted content size: expected at least ${NONCE_SIZE + AUTH_TAG_SIZE} bytes, got ${encryptedContent.length} bytes`
+    );
+  }
+
+  const dek = unwrapDek(wrappedDek, kek, fileId);
+
+  try {
+    // Extract nonce and ciphertext (format: [nonce(12)][ciphertext + authTag])
+    const nonce = encryptedContent.slice(0, NONCE_SIZE);
+    const ciphertext = encryptedContent.slice(NONCE_SIZE);
+
+    const cipher = chacha20poly1305(dek, nonce);
+    return cipher.decrypt(ciphertext);
+  } finally {
+    dek.fill(0);
+  }
+}

--- a/packages/encryption/tests/property/test_envelope_encryption.test.ts
+++ b/packages/encryption/tests/property/test_envelope_encryption.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Property-Based Tests for Envelope Encryption Module
+ *
+ * These tests verify universal properties that should hold for all inputs.
+ */
+
+import fc from 'fast-check';
+import {
+  generateDek,
+  wrapDek,
+  unwrapDek,
+  encryptFileWithDek,
+  decryptFileWithDek,
+  DekUnwrapError,
+} from '../../src/lib/envelope-encryption';
+
+describe('Envelope Encryption Property Tests', () => {
+  /**
+   * Feature: cortex-backup, Property 32: Envelope encryption round-trip
+   *
+   * Validates: Requirements 28.1, 28.2, 28.3, 29.2, 29.3
+   *
+   * For random content, random KEK, and optional fileId:
+   * - encryptFileWithDek then decryptFileWithDek returns original content
+   * - Encrypted content differs from plaintext
+   * - Wrapped DEK is 65 bytes (no fileId) or 97 bytes (with fileId)
+   * - Version byte is 0x01
+   */
+  test('Property 32: Envelope encryption round-trip (without fileId)', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.uint8Array({ minLength: 0, maxLength: 10000 }), // file content
+        fc.uint8Array({ minLength: 32, maxLength: 32 }),    // KEK
+        async (content, kek) => {
+          const { encryptedContent, wrappedDek } = await encryptFileWithDek(content, kek);
+
+          // Wrapped DEK is 65 bytes without fileId
+          expect(wrappedDek.length).toBe(65);
+
+          // Version byte is 0x01
+          expect(wrappedDek[0]).toBe(0x01);
+
+          // Encrypted content differs from plaintext (for non-empty content)
+          if (content.length > 0) {
+            expect(encryptedContent).not.toEqual(content);
+          }
+
+          // Round-trip returns original content
+          const decrypted = decryptFileWithDek(encryptedContent, wrappedDek, kek);
+          expect(decrypted).toEqual(content);
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  test('Property 32: Envelope encryption round-trip (with fileId)', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.uint8Array({ minLength: 0, maxLength: 10000 }), // file content
+        fc.uint8Array({ minLength: 32, maxLength: 32 }),    // KEK
+        fc.string({ minLength: 1, maxLength: 50 }),         // fileId
+        async (content, kek, fileId) => {
+          const { encryptedContent, wrappedDek } = await encryptFileWithDek(content, kek, fileId);
+
+          // Wrapped DEK is 97 bytes with fileId
+          expect(wrappedDek.length).toBe(97);
+
+          // Version byte is 0x01
+          expect(wrappedDek[0]).toBe(0x01);
+
+          // Encrypted content differs from plaintext (for non-empty content)
+          if (content.length > 0) {
+            expect(encryptedContent).not.toEqual(content);
+          }
+
+          // Round-trip returns original content
+          const decrypted = decryptFileWithDek(encryptedContent, wrappedDek, kek, fileId);
+          expect(decrypted).toEqual(content);
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  test('Property 32: wrapDek/unwrapDek round-trip preserves DEK', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.uint8Array({ minLength: 32, maxLength: 32 }), // DEK
+        fc.uint8Array({ minLength: 32, maxLength: 32 }), // KEK
+        async (dek, kek) => {
+          const wrapped = await wrapDek(dek, kek);
+          const unwrapped = unwrapDek(wrapped, kek);
+          expect(unwrapped).toEqual(dek);
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  test('Property 32: wrapDek/unwrapDek round-trip with HMAC binding', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.uint8Array({ minLength: 32, maxLength: 32 }), // DEK
+        fc.uint8Array({ minLength: 32, maxLength: 32 }), // KEK
+        fc.string({ minLength: 1, maxLength: 50 }),       // fileId
+        async (dek, kek, fileId) => {
+          const wrapped = await wrapDek(dek, kek, fileId);
+          const unwrapped = unwrapDek(wrapped, kek, fileId);
+          expect(unwrapped).toEqual(dek);
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  test('Property 32: Wrong KEK fails decryption', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.uint8Array({ minLength: 1, maxLength: 1000 }), // content
+        fc.uint8Array({ minLength: 32, maxLength: 32 }),   // correct KEK
+        fc.uint8Array({ minLength: 32, maxLength: 32 }),   // wrong KEK
+        async (content, correctKek, wrongKek) => {
+          if (Buffer.from(correctKek).equals(Buffer.from(wrongKek))) {
+            return true;
+          }
+
+          const { encryptedContent, wrappedDek } = await encryptFileWithDek(content, correctKek);
+
+          expect(() => decryptFileWithDek(encryptedContent, wrappedDek, wrongKek)).toThrow(DekUnwrapError);
+          return true;
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  test('Property 32: Wrong fileId fails HMAC verification', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.uint8Array({ minLength: 1, maxLength: 1000 }), // content
+        fc.uint8Array({ minLength: 32, maxLength: 32 }),   // KEK
+        fc.string({ minLength: 1, maxLength: 50 }),        // correct fileId
+        fc.string({ minLength: 1, maxLength: 50 }),        // wrong fileId
+        async (content, kek, correctFileId, wrongFileId) => {
+          if (correctFileId === wrongFileId) {
+            return true;
+          }
+
+          const { encryptedContent, wrappedDek } = await encryptFileWithDek(content, kek, correctFileId);
+
+          expect(() => decryptFileWithDek(encryptedContent, wrappedDek, kek, wrongFileId)).toThrow(DekUnwrapError);
+          return true;
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  /**
+   * Feature: cortex-backup, Property 33: DEK uniqueness
+   *
+   * Validates: Requirements 28.4, 28.5
+   *
+   * - 100 calls to generateDek() produce 100 unique 32-byte keys
+   * - Two files encrypted with the same KEK produce different wrapped DEKs
+   */
+  test('Property 33: generateDek produces unique 32-byte keys', async () => {
+    const deks: Uint8Array[] = [];
+    for (let i = 0; i < 100; i++) {
+      deks.push(await generateDek());
+    }
+
+    // All should be 32 bytes
+    for (const dek of deks) {
+      expect(dek.length).toBe(32);
+    }
+
+    // All should be unique
+    const dekStrings = new Set(deks.map(d => Buffer.from(d).toString('hex')));
+    expect(dekStrings.size).toBe(100);
+  });
+
+  test('Property 33: Two files encrypted with same KEK produce different wrapped DEKs', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.uint8Array({ minLength: 1, maxLength: 1000 }), // content1
+        fc.uint8Array({ minLength: 1, maxLength: 1000 }), // content2
+        fc.uint8Array({ minLength: 32, maxLength: 32 }),   // shared KEK
+        async (content1, content2, kek) => {
+          const result1 = await encryptFileWithDek(content1, kek);
+          const result2 = await encryptFileWithDek(content2, kek);
+
+          // Wrapped DEKs must be different (different random DEKs + nonces)
+          expect(result1.wrappedDek).not.toEqual(result2.wrappedDek);
+
+          // Encrypted content must be different
+          expect(result1.encryptedContent).not.toEqual(result2.encryptedContent);
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  test('Property 33: Same content encrypted twice produces different outputs', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.uint8Array({ minLength: 1, maxLength: 1000 }), // same content
+        fc.uint8Array({ minLength: 32, maxLength: 32 }),   // same KEK
+        async (content, kek) => {
+          const result1 = await encryptFileWithDek(content, kek);
+          const result2 = await encryptFileWithDek(content, kek);
+
+          // Even with identical inputs, outputs differ (unique DEKs + nonces)
+          expect(result1.wrappedDek).not.toEqual(result2.wrappedDek);
+          expect(result1.encryptedContent).not.toEqual(result2.encryptedContent);
+
+          // But both decrypt to the same content
+          const decrypted1 = decryptFileWithDek(result1.encryptedContent, result1.wrappedDek, kek);
+          const decrypted2 = decryptFileWithDek(result2.encryptedContent, result2.wrappedDek, kek);
+          expect(decrypted1).toEqual(content);
+          expect(decrypted2).toEqual(content);
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add envelope encryption module (`packages/encryption/src/lib/envelope-encryption.ts`) with per-file DEK generation, ChaCha20-Poly1305 wrapping/unwrapping, and optional HMAC-SHA256 file binding
- Implement `generateDek`, `wrapDek`, `unwrapDek`, `encryptFileWithDek`, `decryptFileWithDek`, and `DekUnwrapError` with structured error codes
- Add 9 property-based tests covering round-trip correctness (Property 32) and DEK uniqueness (Property 33)
- Update README.md, AGENTS.md, and packages/README.md with envelope encryption documentation
- Mark tasks 6.12.1–6.12.5 as complete

## Security
- DEK zeroed via `try/finally` in all encrypt/decrypt paths and on HMAC verification failure
- KEK/DEK size validation on all entry points
- Constant-time HMAC comparison with defensive length guard
- Minimum encrypted content length validation before decryption
- No key material in error messages or logs
- Key commitment limitation documented in JSDoc

## Test plan
- [x] All 132 tests pass (9 suites), 0 regressions from baseline of 123
- [x] Property 32: envelope encryption round-trip (with and without fileId, wrong KEK, wrong fileId)
- [x] Property 33: 100 unique DEKs, different wrapped DEKs for same KEK, same content produces different outputs
- [x] TypeScript compiles clean (`tsc --noEmit`)