### PR TITLE
feat: implement file sharing system (task 17)

### DIFF
--- a/.kiro/specs/cortex/tasks.md
+++ b/.kiro/specs/cortex/tasks.md
@@ -774,8 +774,8 @@
   - **Property 22: Vault password change requires DEK re-wrapping**
   - **Validates: Requirements 23.3, 23.4**
 
-- [ ] 17. Implement file sharing system
-- [ ] 17.1 Build frontend share creation with envelope encryption
+- [x] 17. Implement file sharing system
+- [x] 17.1 Build frontend share creation with envelope encryption
   - Require share password (no passwordless sharing)
   - Validate password meets minimum strength requirements (16+ chars with 80 bits entropy)
   - Generate random share salt (16 bytes)
@@ -789,13 +789,13 @@
   - Provide alternative share ID + password entry method for truncated URLs
   - _Requirements: 17.1, 17.2, 17.3, 17.4, 17.5, 17.10, 17.11, 18.3, 31.1, 31.2, 31.3, 31.4_
 
-- [ ] 17.2 Create share route handlers
+- [x] 17.2 Create share route handlers
   - Implement POST /v1/shares route (create share metadata only, no keys)
   - Implement GET /v1/shares/{id} route (access share, anonymous)
   - Implement DELETE /v1/shares/{id} route (revoke share)
   - _Requirements: 17.4, 17.5, 17.7, 18.2, 18.5_
 
-- [ ] 17.3 Create share service layer with server-side rate limiting
+- [x] 17.3 Create share service layer with server-side rate limiting
   - Store share metadata only (share ID, file reference, creation time, optional expiration, access count)
   - Never store any key material (DEK, wrapped DEK, share key, salt, HMAC)
   - Validate share access (check optional expiration and revocation)
@@ -807,7 +807,7 @@
   - Track access count and last accessed time
   - _Requirements: 17.4, 17.5, 17.7, 18.1, 18.2, 18.5, 18.6, 18.7, 18.9, 31.5_
 
-- [ ] 17.4 Build frontend share access with envelope encryption and HMAC verification
+- [x] 17.4 Build frontend share access with envelope encryption and HMAC verification
   - Extract password-wrapped DEK, salt, and HMAC from URL fragment
   - Fetch share metadata (shareId, expiration) from server
   - Prompt for share password
@@ -824,7 +824,7 @@
   - Overwrite DEK buffer with zeros before dereferencing
   - _Requirements: 17.5, 17.6, 17.7, 17.8, 18.4, 18.5, 31.6_
 
-- [ ]* 17.5 Write property test for share keys enable file access without vault password
+- [x]* 17.5 Write property test for share keys enable file access without vault password
   - **Property 20: Share keys enable file access without vault password**
   - **Validates: Requirements 17.1, 17.4**
 

--- a/cdk/lib/stacks/service.ts
+++ b/cdk/lib/stacks/service.ts
@@ -196,7 +196,7 @@ export class ServiceStack extends Stack {
         //
         // Note: Share key is NOT stored (embedded in URL fragment)
         // Requirements: 17.3
-        return new TableV2(this, "SharesTable", {
+        const table = new TableV2(this, "SharesTable", {
             tableName: this.resourceName("shares"),
             partitionKey: {
                 name: "PK",
@@ -206,8 +206,10 @@ export class ServiceStack extends Stack {
                 name: "SK",
                 type: AttributeType.STRING,
             },
+            timeToLiveAttribute: "ttl",
             ...DYNAMODB_DEFAULT_PROPS,
         });
+        return table;
     }
 
     private createApiHandler(): Lambda {

--- a/cdk/lib/stacks/service.ts
+++ b/cdk/lib/stacks/service.ts
@@ -221,11 +221,16 @@ export class ServiceStack extends Stack {
             code: Code.fromAsset("../lambda/src/api"),
             environment: {
                 STAGE: this.props.stage.stageType,
-                DATA_TABLE: this.dataTable.tableName,
-                SHARES_TABLE: this.sharesTable.tableName,
-                BUCKET_NAME: this.bucket.bucketName,
-                USER_POOL_ID: this.props.userPool.userPoolId,
-                USER_POOL_CLIENT_ID: this.props.userPoolClient.userPoolClientId,
+                // Single data table serves as vaults, items, collections, and recovery table
+                VAULTS_TABLE_NAME: this.dataTable.tableName,
+                ITEMS_TABLE_NAME: this.dataTable.tableName,
+                COLLECTIONS_TABLE_NAME: this.dataTable.tableName,
+                RECOVERY_TABLE_NAME: this.dataTable.tableName,
+                // Separate shares table for anonymous access security isolation
+                SHARES_TABLE_NAME: this.sharesTable.tableName,
+                FILES_BUCKET_NAME: this.bucket.bucketName,
+                COGNITO_USER_POOL_ID: this.props.userPool.userPoolId,
+                COGNITO_USER_POOL_CLIENT_ID: this.props.userPoolClient.userPoolClientId,
                 POWERTOOLS_SERVICE_NAME: "cortex-api",
                 POWERTOOLS_METRICS_NAMESPACE: "Cortex",
                 LOG_LEVEL: "INFO",

--- a/docs/plans/2026-02-06-file-sharing-design.md
+++ b/docs/plans/2026-02-06-file-sharing-design.md
@@ -1,0 +1,207 @@
+# File Sharing System Design
+
+**Task:** 17 (subtasks 17.1-17.5)
+**Date:** 2026-02-06
+**Status:** Approved
+
+## Overview
+
+Password-protected file sharing with envelope encryption. The server never sees key material - all cryptographic operations happen in the frontend. Recipients access shared files using only the share password, without needing the vault password.
+
+## Architecture
+
+### Data Flow
+
+**Creator (share creation):**
+1. Enter share password → derive share encryption key (Argon2id) and HMAC key (HKDF)
+2. Unwrap file's DEK using vault KEK → re-wrap DEK with share encryption key
+3. POST metadata-only request to backend (no key material)
+4. Construct share URL with wrapped DEK, salt, and HMAC in URL fragment (never sent to server)
+
+**Recipient (share access):**
+1. Open share URL → extract blob from fragment
+2. Fetch share metadata from server (shareId, expiresAt, downloadUrl)
+3. Enter share password → verify HMAC over metadata → derive share key → unwrap DEK
+4. Download encrypted file via presigned URL → decrypt with DEK
+
+### Components
+
+| Component | Path | Purpose |
+|-----------|------|---------|
+| Share encryption | `packages/encryption/src/lib/share-encryption.ts` | Key derivation, DEK wrapping, HMAC |
+| Share service | `lambda/src/api/services/share_service.py` | Business logic, rate limiting |
+| Share routes | `lambda/src/api/routes/shares.py` | HTTP handlers (replace stubs) |
+| Pydantic models | `lambda/src/shared/models.py` | Request/response validation |
+| Property test | `packages/encryption/tests/property/test_share_encryption.test.ts` | Share round-trip property |
+| Frontend | `packages/web/src/` | Share creation and access UI |
+
+## Encryption Design
+
+### Key Derivation Chain
+
+```
+share_password + share_salt (16 bytes random)
+    → Argon2id(64MB, 3 iterations, 4 parallelism)
+    → share_master_key (32 bytes)
+
+share_master_key
+    → HKDF-SHA256(context: "cortex-share-key-v1")
+    → share_encryption_key (32 bytes)  [wraps DEK]
+
+share_master_key
+    → HKDF-SHA256(context: "cortex-share-hmac-v1")
+    → hmac_key (32 bytes)  [signs metadata]
+```
+
+### DEK Re-wrapping
+
+- Unwrap file's DEK using vault's KEK (existing `unwrapDek()`)
+- Re-wrap DEK using share encryption key (existing `wrapDek()` with share key)
+- Zero original DEK immediately after re-wrapping
+
+### HMAC Metadata Binding
+
+- `HMAC-SHA256(hmac_key, shareId || expiresAt)`
+- Binds URL fragment to server-side metadata
+- Prevents share ID swapping attacks
+- Verified client-side with constant-time comparison
+
+### Share Password Requirements
+
+- Minimum 16 characters
+- Minimum 80 bits entropy
+
+## URL Format
+
+### Share URL
+
+```
+https://app.cortex.dev/s/{shareId}#{base64url_blob}
+```
+
+Blob is base64url-encoded binary (opaque, no parameter names visible):
+
+```
+[version(1)][salt(16)][wrappedDek(65)][hmac(32)] = 114 bytes → ~152 chars base64url
+```
+
+### Alternative Access
+
+For truncated URLs: navigate to `/s`, enter share ID and password manually.
+
+## Data Model
+
+### DynamoDB Shares Table
+
+**Share metadata row:**
+
+```
+PK: SHARE#{shareId}
+SK: METADATA
+shareId: str
+itemId: str
+vaultId: str
+userId: str
+createdAt: int          (Unix epoch)
+expiresAt: int          (Unix epoch, optional)
+isRevoked: bool         (default false)
+accessCount: int        (default 0)
+lastAccessedAt: int     (Unix epoch, optional)
+ttl: int                (DynamoDB TTL attribute)
+```
+
+**Rate limit row (same table):**
+
+```
+PK: SHARE#{shareId}
+SK: RATE#{ipAddress}
+attemptCount: int
+windowStart: int        (Unix epoch, hourly window)
+ttl: int                (windowStart + 7200)
+```
+
+### TTL Strategy
+
+| Scenario | TTL Value |
+|----------|-----------|
+| Expiring share | `expiresAt + 86400` (24h grace) |
+| No expiration | No TTL attribute |
+| Revoked share | `revokedAt + 604800` (7 days for audit) |
+| Rate limit row | `windowStart + 7200` (2h after window) |
+
+## Rate Limiting
+
+Three layers:
+
+1. **API Gateway throttling** - Infrastructure-level abuse prevention on `GET /v1/shares/{shareId}`
+2. **Server-side per-share tracking** - DynamoDB `RATE#{ip}` rows, max 5 attempts per IP per share per hour, HTTP 429 with Retry-After
+3. **Client-side exponential backoff** - After 3 failed decryption attempts in browser
+
+## Service Layer
+
+### ShareService
+
+```python
+class ShareService:
+    def create_share(user_id, request) -> CreateShareResponse
+        # Verify user owns the item (query items table)
+        # Generate UUID shareId
+        # Store metadata (no key material)
+        # Set TTL if expiresAt provided
+        # Return shareId, createdAt, expiresAt
+
+    def get_share(share_id, client_ip) -> GetShareResponse
+        # Check rate limit for IP + shareId
+        # Fetch share metadata
+        # Check revoked → ShareRevokedError
+        # Check expired → ShareExpiredError
+        # Generate presigned S3 download URL
+        # Increment access count, update lastAccessedAt
+        # Return metadata + download URL
+
+    def revoke_share(user_id, share_id) -> RevokeShareResponse
+        # Verify user owns the share
+        # Set isRevoked = True, set TTL (7 days)
+        # Return confirmation
+
+    def check_rate_limit(share_id, client_ip) -> None
+        # Query RATE#{ip} row for current hour window
+        # If count >= 5: raise HTTP 429 with Retry-After
+        # Otherwise: increment count
+```
+
+## Frontend
+
+### Share Encryption Module
+
+`packages/encryption/src/lib/share-encryption.ts`:
+
+```typescript
+deriveShareKeys(password, salt) → {encryptionKey, hmacKey}
+computeShareHmac(hmacKey, shareId, expiresAt?) → Uint8Array
+verifyShareHmac(hmacKey, shareId, expiresAt, expectedHmac) → boolean
+encodeShareBlob(version, salt, wrappedDek, hmac) → string  // base64url
+decodeShareBlob(blob) → {version, salt, wrappedDek, hmac}
+validateSharePasswordStrength(password) → {valid, score, feedback}
+```
+
+### Share Creation UI
+
+1. User selects file → clicks "Share"
+2. Share dialog: password input (strength meter), expiration picker, URL shortener warning
+3. On submit: derive keys, re-wrap DEK, POST metadata, construct URL
+4. Display URL with copy button + fallback share ID
+
+### Share Access UI
+
+1. Open URL → extract shareId from path, blob from fragment
+2. Fetch metadata from server
+3. Prompt for password → verify HMAC → derive key → unwrap DEK
+4. Download and decrypt file → trigger browser download
+5. Zero DEK from memory
+
+## Property Test
+
+**Property 20: Share keys enable file access without vault password**
+
+Validates: encrypt file with vault KEK → create share (re-wrap DEK) → access share with only share password → decrypt matches original. 50 property test runs.

--- a/docs/plans/2026-02-06-file-sharing-implementation.md
+++ b/docs/plans/2026-02-06-file-sharing-implementation.md
@@ -1,0 +1,2254 @@
+# File Sharing System Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement password-protected file sharing with envelope encryption, where the server never sees key material and recipients access shared files using only the share password.
+
+**Architecture:** Frontend encryption library handles key derivation (Argon2id + HKDF), DEK re-wrapping, HMAC metadata binding, and blob encoding. Backend stores only share metadata (never keys) in DynamoDB with TTL for cleanup. Three-layer rate limiting: API Gateway throttling, server-side per-share/IP tracking, client-side exponential backoff.
+
+**Tech Stack:** TypeScript (@noble/ciphers, @noble/hashes, argon2id, fast-check), Python 3.11 (Lambda Powertools, Pydantic, boto3), React 19, DynamoDB, S3
+
+**Design doc:** `docs/plans/2026-02-06-file-sharing-design.md`
+
+---
+
+## Task 0: Fix CDK ↔ Lambda Environment Variable Mismatches
+
+CDK sets `DATA_TABLE`, `SHARES_TABLE`, `BUCKET_NAME` but Lambda service provider reads `ITEMS_TABLE_NAME` / `SHARES_TABLE_NAME` / `FILES_BUCKET_NAME` etc. The `dataTable` in CDK is a single table used for vaults, items, collections, and recovery (single-table design), but the Python service provider reads 4 separate env vars for it.
+
+**Files:**
+- Modify: `cdk/lib/stacks/service.ts` (lines 222-228) - add all env vars
+- Modify: `lambda/src/environment/service_provider.py` - no change needed (it already reads the correct names)
+
+### Step 1: Update CDK Lambda environment variables
+
+In `cdk/lib/stacks/service.ts`, replace the environment block in `createApiHandler()` (lines 222-232):
+
+```typescript
+            environment: {
+                STAGE: this.props.stage.stageType,
+                // Single data table serves as vaults, items, collections, and recovery table
+                VAULTS_TABLE_NAME: this.dataTable.tableName,
+                ITEMS_TABLE_NAME: this.dataTable.tableName,
+                COLLECTIONS_TABLE_NAME: this.dataTable.tableName,
+                RECOVERY_TABLE_NAME: this.dataTable.tableName,
+                // Separate shares table for anonymous access security isolation
+                SHARES_TABLE_NAME: this.sharesTable.tableName,
+                FILES_BUCKET_NAME: this.bucket.bucketName,
+                COGNITO_USER_POOL_ID: this.props.userPool.userPoolId,
+                COGNITO_USER_POOL_CLIENT_ID: this.props.userPoolClient.userPoolClientId,
+                POWERTOOLS_SERVICE_NAME: "cortex-api",
+                POWERTOOLS_METRICS_NAMESPACE: "Cortex",
+                LOG_LEVEL: "INFO",
+            },
+```
+
+### Step 2: Update service_provider to match Cognito env var name
+
+In `lambda/src/environment/service_provider.py`, the `auth_service` property (line 104) already reads `COGNITO_USER_POOL_ID` which now matches. Verify no other mismatches exist.
+
+### Step 3: Run all existing tests
+
+Run: `cd /Users/lcmessen/cortex/lambda && python -m pytest -v`
+Expected: All tests PASS (tests use fixture env vars, not CDK env vars)
+
+Run: `cd /Users/lcmessen/cortex/cdk && npx cdk synth --quiet`
+Expected: Successful synthesis
+
+### Step 4: Commit
+
+```bash
+git add cdk/lib/stacks/service.ts
+git commit -m "fix: align CDK Lambda env vars with service provider expectations"
+```
+
+---
+
+## Task 1: Share Encryption Module
+
+**Files:**
+- Create: `packages/encryption/src/lib/share-encryption.ts`
+- Modify: `packages/encryption/src/index.ts`
+
+### Step 1: Write the failing tests
+
+Create `packages/encryption/tests/unit/test_share_encryption.test.ts`:
+
+```typescript
+import {
+  deriveShareKeys,
+  computeShareHmac,
+  verifyShareHmac,
+  encodeShareBlob,
+  decodeShareBlob,
+} from '../../src/lib/share-encryption';
+
+describe('Share Encryption', () => {
+  const password = 'test-share-password-16chars!';
+  const salt = new Uint8Array(16).fill(42);
+
+  describe('deriveShareKeys', () => {
+    test('derives 32-byte encryption key and 32-byte HMAC key', async () => {
+      const { encryptionKey, hmacKey } = await deriveShareKeys(password, salt);
+      expect(encryptionKey.length).toBe(32);
+      expect(hmacKey.length).toBe(32);
+    });
+
+    test('same password + salt produces same keys', async () => {
+      const keys1 = await deriveShareKeys(password, salt);
+      const keys2 = await deriveShareKeys(password, salt);
+      expect(keys1.encryptionKey).toEqual(keys2.encryptionKey);
+      expect(keys1.hmacKey).toEqual(keys2.hmacKey);
+    });
+
+    test('different passwords produce different keys', async () => {
+      const keys1 = await deriveShareKeys(password, salt);
+      const keys2 = await deriveShareKeys('different-password-16chars!', salt);
+      expect(keys1.encryptionKey).not.toEqual(keys2.encryptionKey);
+    });
+
+    test('different salts produce different keys', async () => {
+      const salt2 = new Uint8Array(16).fill(99);
+      const keys1 = await deriveShareKeys(password, salt);
+      const keys2 = await deriveShareKeys(password, salt2);
+      expect(keys1.encryptionKey).not.toEqual(keys2.encryptionKey);
+    });
+
+    test('encryption key differs from HMAC key', async () => {
+      const { encryptionKey, hmacKey } = await deriveShareKeys(password, salt);
+      expect(encryptionKey).not.toEqual(hmacKey);
+    });
+  });
+
+  describe('computeShareHmac / verifyShareHmac', () => {
+    test('compute returns 32-byte HMAC', async () => {
+      const { hmacKey } = await deriveShareKeys(password, salt);
+      const mac = computeShareHmac(hmacKey, 'share-123', 1700000000);
+      expect(mac.length).toBe(32);
+    });
+
+    test('verify returns true for matching HMAC', async () => {
+      const { hmacKey } = await deriveShareKeys(password, salt);
+      const mac = computeShareHmac(hmacKey, 'share-123', 1700000000);
+      expect(verifyShareHmac(hmacKey, 'share-123', 1700000000, mac)).toBe(true);
+    });
+
+    test('verify returns false for wrong shareId', async () => {
+      const { hmacKey } = await deriveShareKeys(password, salt);
+      const mac = computeShareHmac(hmacKey, 'share-123', 1700000000);
+      expect(verifyShareHmac(hmacKey, 'share-456', 1700000000, mac)).toBe(false);
+    });
+
+    test('verify returns false for wrong expiresAt', async () => {
+      const { hmacKey } = await deriveShareKeys(password, salt);
+      const mac = computeShareHmac(hmacKey, 'share-123', 1700000000);
+      expect(verifyShareHmac(hmacKey, 'share-123', 1700099999, mac)).toBe(false);
+    });
+
+    test('handles undefined expiresAt', async () => {
+      const { hmacKey } = await deriveShareKeys(password, salt);
+      const mac = computeShareHmac(hmacKey, 'share-123', undefined);
+      expect(verifyShareHmac(hmacKey, 'share-123', undefined, mac)).toBe(true);
+    });
+  });
+
+  describe('encodeShareBlob / decodeShareBlob', () => {
+    test('round-trip preserves data', () => {
+      const version = 1;
+      const wrappedDek = new Uint8Array(65).fill(7);
+      const hmacVal = new Uint8Array(32).fill(8);
+
+      const encoded = encodeShareBlob(version, salt, wrappedDek, hmacVal);
+      const decoded = decodeShareBlob(encoded);
+
+      expect(decoded.version).toBe(version);
+      expect(decoded.salt).toEqual(salt);
+      expect(decoded.wrappedDek).toEqual(wrappedDek);
+      expect(decoded.hmac).toEqual(hmacVal);
+    });
+
+    test('encoded blob is base64url string', () => {
+      const encoded = encodeShareBlob(1, salt, new Uint8Array(65), new Uint8Array(32));
+      // base64url: no +, /, or = padding
+      expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+
+    test('blob is 114 bytes raw (152 chars base64url)', () => {
+      const encoded = encodeShareBlob(1, salt, new Uint8Array(65), new Uint8Array(32));
+      // 114 bytes = ceil(114 * 4/3) = 152 chars base64url (no padding)
+      expect(encoded.length).toBe(152);
+    });
+
+    test('throws on invalid blob', () => {
+      expect(() => decodeShareBlob('short')).toThrow();
+    });
+  });
+});
+```
+
+### Step 2: Run tests to verify they fail
+
+Run: `cd /Users/lcmessen/cortex && npx --workspace=packages/encryption jest tests/unit/test_share_encryption.test.ts`
+Expected: FAIL with "Cannot find module '../../src/lib/share-encryption'"
+
+### Step 3: Write share-encryption.ts implementation
+
+Create `packages/encryption/src/lib/share-encryption.ts`:
+
+```typescript
+/**
+ * Share Encryption Module
+ *
+ * Handles key derivation, HMAC computation, and blob encoding for
+ * password-protected file sharing. The server never sees key material.
+ *
+ * Key derivation chain:
+ *   share_password + salt → Argon2id → share_master_key
+ *   share_master_key → HKDF("cortex-share-key-v1") → encryption_key
+ *   share_master_key → HKDF("cortex-share-hmac-v1") → hmac_key
+ *
+ * Requirements: 17.1, 17.2, 17.3, 17.4, 17.5, 17.10, 17.11, 31.1-31.6
+ */
+
+import { hkdf } from '@noble/hashes/hkdf';
+import { sha256 } from '@noble/hashes/sha2';
+import { hmac } from '@noble/hashes/hmac';
+import { initArgon2idLoader } from 'argon2id';
+
+const SHARE_BLOB_VERSION = 0x01;
+const SALT_SIZE = 16;
+const WRAPPED_DEK_SIZE = 65;
+const HMAC_SIZE = 32;
+const BLOB_SIZE = 1 + SALT_SIZE + WRAPPED_DEK_SIZE + HMAC_SIZE; // 114
+
+const ARGON2_PARAMS = {
+  memorySize: 65536, // 64MB in KB
+  passes: 3,
+  parallelism: 4,
+  tagLength: 32,
+};
+
+const HKDF_SALT_ENCRYPTION = new TextEncoder().encode('cortex-salt-share-enc-v1');
+const HKDF_SALT_HMAC = new TextEncoder().encode('cortex-salt-share-hmac-v1');
+const HKDF_CONTEXT_ENCRYPTION = new TextEncoder().encode('cortex-share-key-v1');
+const HKDF_CONTEXT_HMAC = new TextEncoder().encode('cortex-share-hmac-v1');
+
+let argon2idInstance: ((params: {
+  password: Uint8Array;
+  salt: Uint8Array;
+  parallelism: number;
+  passes: number;
+  memorySize: number;
+  tagLength: number;
+}) => Uint8Array) | null = null;
+
+async function getArgon2id() {
+  if (!argon2idInstance) {
+    const loader = await initArgon2idLoader();
+    argon2idInstance = await loader();
+  }
+  return argon2idInstance;
+}
+
+export interface ShareKeys {
+  encryptionKey: Uint8Array;
+  hmacKey: Uint8Array;
+}
+
+/**
+ * Derive share encryption key and HMAC key from a share password and salt.
+ *
+ * @param password - The share password (16+ chars, 80+ bits entropy)
+ * @param salt - Random 16-byte salt
+ * @returns ShareKeys with 32-byte encryptionKey and 32-byte hmacKey
+ */
+export async function deriveShareKeys(password: string, salt: Uint8Array): Promise<ShareKeys> {
+  if (salt.length !== SALT_SIZE) {
+    throw new Error(`Invalid salt size: expected ${SALT_SIZE} bytes, got ${salt.length}`);
+  }
+
+  const argon2id = await getArgon2id();
+  const passwordBytes = new TextEncoder().encode(password);
+
+  const masterKey = argon2id({
+    password: passwordBytes,
+    salt,
+    ...ARGON2_PARAMS,
+  });
+
+  const encryptionKey = hkdf(sha256, masterKey, HKDF_SALT_ENCRYPTION, HKDF_CONTEXT_ENCRYPTION, 32);
+  const hmacKey = hkdf(sha256, masterKey, HKDF_SALT_HMAC, HKDF_CONTEXT_HMAC, 32);
+
+  masterKey.fill(0);
+
+  return { encryptionKey, hmacKey };
+}
+
+/**
+ * Compute HMAC-SHA256 over share metadata.
+ * Binds the URL fragment to server-side metadata to prevent share ID swapping.
+ *
+ * @param hmacKey - 32-byte HMAC key from deriveShareKeys
+ * @param shareId - The share identifier
+ * @param expiresAt - Optional expiration timestamp (Unix epoch)
+ * @returns 32-byte HMAC
+ */
+export function computeShareHmac(
+  hmacKey: Uint8Array,
+  shareId: string,
+  expiresAt?: number
+): Uint8Array {
+  const expiresStr = expiresAt !== undefined ? String(expiresAt) : '';
+  const message = new TextEncoder().encode(shareId + '|' + expiresStr);
+  return hmac(sha256, hmacKey, message);
+}
+
+/**
+ * Verify HMAC over share metadata using constant-time comparison.
+ *
+ * @param hmacKey - 32-byte HMAC key
+ * @param shareId - The share identifier
+ * @param expiresAt - Expiration timestamp from server
+ * @param expectedHmac - HMAC from URL fragment
+ * @returns true if HMAC matches
+ */
+export function verifyShareHmac(
+  hmacKey: Uint8Array,
+  shareId: string,
+  expiresAt: number | undefined,
+  expectedHmac: Uint8Array
+): boolean {
+  const computed = computeShareHmac(hmacKey, shareId, expiresAt);
+
+  if (computed.length !== expectedHmac.length) return false;
+
+  let diff = 0;
+  for (let i = 0; i < computed.length; i++) {
+    diff |= computed[i] ^ expectedHmac[i];
+  }
+  return diff === 0;
+}
+
+/**
+ * Encode share data into a base64url blob for the URL fragment.
+ * Format: [version(1)][salt(16)][wrappedDek(65)][hmac(32)] = 114 bytes
+ *
+ * @returns base64url-encoded string (~152 chars)
+ */
+export function encodeShareBlob(
+  version: number,
+  salt: Uint8Array,
+  wrappedDek: Uint8Array,
+  hmacVal: Uint8Array
+): string {
+  if (salt.length !== SALT_SIZE) throw new Error(`Invalid salt size: ${salt.length}`);
+  if (wrappedDek.length !== WRAPPED_DEK_SIZE) throw new Error(`Invalid wrappedDek size: ${wrappedDek.length}`);
+  if (hmacVal.length !== HMAC_SIZE) throw new Error(`Invalid HMAC size: ${hmacVal.length}`);
+
+  const blob = new Uint8Array(BLOB_SIZE);
+  let offset = 0;
+
+  blob[offset] = version;
+  offset += 1;
+
+  blob.set(salt, offset);
+  offset += SALT_SIZE;
+
+  blob.set(wrappedDek, offset);
+  offset += WRAPPED_DEK_SIZE;
+
+  blob.set(hmacVal, offset);
+
+  return uint8ArrayToBase64url(blob);
+}
+
+/**
+ * Decode a base64url blob from the URL fragment.
+ *
+ * @param encoded - base64url-encoded string
+ * @returns Decoded share data
+ */
+export function decodeShareBlob(encoded: string): {
+  version: number;
+  salt: Uint8Array;
+  wrappedDek: Uint8Array;
+  hmac: Uint8Array;
+} {
+  const blob = base64urlToUint8Array(encoded);
+
+  if (blob.length !== BLOB_SIZE) {
+    throw new Error(`Invalid share blob size: expected ${BLOB_SIZE} bytes, got ${blob.length}`);
+  }
+
+  let offset = 0;
+
+  const version = blob[offset];
+  offset += 1;
+
+  const salt = blob.slice(offset, offset + SALT_SIZE);
+  offset += SALT_SIZE;
+
+  const wrappedDek = blob.slice(offset, offset + WRAPPED_DEK_SIZE);
+  offset += WRAPPED_DEK_SIZE;
+
+  const hmacVal = blob.slice(offset, offset + HMAC_SIZE);
+
+  return { version, salt, wrappedDek, hmac: hmacVal };
+}
+
+// --- base64url helpers ---
+
+function uint8ArrayToBase64url(bytes: Uint8Array): string {
+  const binary = String.fromCharCode(...bytes);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64urlToUint8Array(str: string): Uint8Array {
+  const base64 = str.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
+  const binary = atob(padded);
+  return new Uint8Array([...binary].map(c => c.charCodeAt(0)));
+}
+```
+
+### Step 4: Add exports to index.ts
+
+Modify `packages/encryption/src/index.ts` - add at the end:
+
+```typescript
+// Export share encryption functions
+export {
+  deriveShareKeys,
+  computeShareHmac,
+  verifyShareHmac,
+  encodeShareBlob,
+  decodeShareBlob,
+  type ShareKeys,
+} from './lib/share-encryption';
+```
+
+### Step 5: Run tests to verify they pass
+
+Run: `cd /Users/lcmessen/cortex && npx --workspace=packages/encryption jest tests/unit/test_share_encryption.test.ts`
+Expected: All tests PASS
+
+### Step 6: Commit
+
+```bash
+git add packages/encryption/src/lib/share-encryption.ts packages/encryption/src/index.ts packages/encryption/tests/unit/test_share_encryption.test.ts
+git commit -m "feat: add share encryption module with key derivation and blob encoding"
+```
+
+---
+
+## Task 2: Share Service Layer (Python)
+
+**Files:**
+- Create: `lambda/src/api/services/share_service.py`
+- Modify: `lambda/src/shared/models.py` (add request/response models)
+
+### Step 1: Add Pydantic models for share requests/responses
+
+Modify `lambda/src/shared/models.py`. Add before the `ErrorResponse` class (around line 636):
+
+```python
+# ============================================================================
+# Share Request/Response Models
+# ============================================================================
+
+
+class CreateShareRequest(BaseModel):
+    """Request model for creating a share."""
+
+    item_id: str = Field(..., description="Item to share")
+    expires_at: Optional[int] = Field(default=None, description="Expiration timestamp (Unix epoch)")
+
+
+class CreateShareResponse(BaseModel):
+    """Response model for share creation."""
+
+    share_id: str = Field(..., description="Share identifier")
+    created_at: int = Field(..., description="Creation timestamp (Unix epoch)")
+    expires_at: Optional[int] = Field(default=None, description="Expiration timestamp")
+
+
+class GetShareResponse(BaseModel):
+    """Response model for share access."""
+
+    share_id: str = Field(..., description="Share identifier")
+    item_id: str = Field(..., description="Item identifier")
+    download_url: str = Field(..., description="Presigned S3 download URL")
+    url_expires_at: int = Field(..., description="URL expiration (Unix epoch)")
+    expires_at: Optional[int] = Field(default=None, description="Share expiration (Unix epoch)")
+
+
+class RevokeShareResponse(BaseModel):
+    """Response model for share revocation."""
+
+    message: str = Field(..., description="Confirmation message")
+    revoked_at: int = Field(..., description="Revocation timestamp (Unix epoch)")
+```
+
+Also update `DynamoDBShareItem` to add the `ttl` field. Around line 607, change:
+
+```python
+class DynamoDBShareItem(BaseModel):
+    """DynamoDB item model for shares."""
+
+    PK: str = Field(..., description="Partition key: SHARE#{shareId}")
+    SK: str = Field(..., description="Sort key: METADATA")
+    share_id: str = Field(..., description="Share identifier")
+    item_id: str = Field(..., description="Item identifier")
+    vault_id: str = Field(..., description="Vault identifier")
+    user_id: str = Field(..., description="Owner user identifier")
+    created_at: int = Field(..., description="Creation timestamp (Unix epoch)")
+    expires_at: Optional[int] = Field(default=None, description="Expiration timestamp (Unix epoch)")
+    is_revoked: bool = Field(default=False, description="Revocation flag")
+    access_count: int = Field(default=0, description="Access counter")
+    last_accessed_at: Optional[int] = Field(default=None, description="Last access timestamp")
+    ttl: Optional[int] = Field(default=None, description="DynamoDB TTL for auto-cleanup")
+```
+
+Note: the existing model uses `file_id` but the Smithy model and design doc use `item_id`. Change the field name from `file_id` to `item_id` to match. Also change `is_password_protected` to be removed since the server doesn't need to know this (password handling is entirely client-side).
+
+### Step 2: Write the failing tests for ShareService
+
+Create `lambda/tests/unit/services/test_share_service.py`:
+
+```python
+"""
+Unit tests for share service layer.
+"""
+
+import json
+import time
+import uuid
+from unittest.mock import patch
+
+import pytest
+from botocore.stub import ANY
+
+from src.api.services.share_service import ShareService
+from src.shared.models import CreateShareRequest
+
+
+class TestCreateShare:
+    """Test suite for ShareService.create_share."""
+
+    def test_create_share_success(self, share_service, dynamodb_stubber):
+        """Create share stores metadata and returns share ID."""
+        user_id = "test-user-123"
+        item_id = "test-item-456"
+        vault_id = "test-vault-789"
+
+        # Stub get_item for item lookup
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"ITEM#{item_id}"},
+                    "SK": {"S": "METADATA"},
+                    "item_id": {"S": item_id},
+                    "vault_id": {"S": vault_id},
+                    "user_id": {"S": user_id},
+                    "item_type": {"S": "MEDIA"},
+                    "s3_key": {"S": f"vaults/{vault_id}/{item_id}"},
+                    "upload_status": {"S": "COMPLETE"},
+                    "encrypted_metadata": {"B": b"encrypted"},
+                    "created_at": {"N": str(int(time.time()))},
+                }
+            },
+            {"TableName": "test-items-table", "Key": ANY},
+        )
+
+        # Stub put_item for share creation
+        dynamodb_stubber.add_response(
+            "put_item",
+            {},
+            {"TableName": "test-shares-table", "Item": ANY, "ConditionExpression": ANY},
+        )
+
+        request = CreateShareRequest(item_id=item_id)
+        response = share_service.create_share(user_id, request)
+
+        assert response.share_id is not None
+        assert len(response.share_id) > 0
+        assert response.created_at > 0
+
+    def test_create_share_with_expiration(self, share_service, dynamodb_stubber):
+        """Create share with expiration sets TTL."""
+        user_id = "test-user-123"
+        item_id = "test-item-456"
+        vault_id = "test-vault-789"
+        expires_at = int(time.time()) + 86400  # 1 day from now
+
+        # Stub get_item
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"ITEM#{item_id}"},
+                    "SK": {"S": "METADATA"},
+                    "item_id": {"S": item_id},
+                    "vault_id": {"S": vault_id},
+                    "user_id": {"S": user_id},
+                    "item_type": {"S": "MEDIA"},
+                    "s3_key": {"S": f"vaults/{vault_id}/{item_id}"},
+                    "upload_status": {"S": "COMPLETE"},
+                    "encrypted_metadata": {"B": b"encrypted"},
+                    "created_at": {"N": str(int(time.time()))},
+                }
+            },
+            {"TableName": "test-items-table", "Key": ANY},
+        )
+
+        # Stub put_item
+        dynamodb_stubber.add_response(
+            "put_item",
+            {},
+            {"TableName": "test-shares-table", "Item": ANY, "ConditionExpression": ANY},
+        )
+
+        request = CreateShareRequest(item_id=item_id, expires_at=expires_at)
+        response = share_service.create_share(user_id, request)
+
+        assert response.expires_at == expires_at
+
+    def test_create_share_item_not_found(self, share_service, dynamodb_stubber):
+        """Create share fails if item doesn't exist."""
+        user_id = "test-user-123"
+
+        # Stub get_item returns empty
+        dynamodb_stubber.add_response(
+            "get_item",
+            {},
+            {"TableName": "test-items-table", "Key": ANY},
+        )
+
+        request = CreateShareRequest(item_id="nonexistent")
+        with pytest.raises(Exception, match="not found"):
+            share_service.create_share(user_id, request)
+
+    def test_create_share_wrong_owner(self, share_service, dynamodb_stubber):
+        """Create share fails if user doesn't own the item."""
+        user_id = "test-user-123"
+        item_id = "test-item-456"
+
+        # Stub get_item - different user owns the item
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"ITEM#{item_id}"},
+                    "SK": {"S": "METADATA"},
+                    "item_id": {"S": item_id},
+                    "vault_id": {"S": "vault"},
+                    "user_id": {"S": "other-user"},
+                    "item_type": {"S": "MEDIA"},
+                    "s3_key": {"S": "key"},
+                    "upload_status": {"S": "COMPLETE"},
+                    "encrypted_metadata": {"B": b"encrypted"},
+                    "created_at": {"N": str(int(time.time()))},
+                }
+            },
+            {"TableName": "test-items-table", "Key": ANY},
+        )
+
+        request = CreateShareRequest(item_id=item_id)
+        with pytest.raises(Exception, match="not found"):
+            share_service.create_share(user_id, request)
+
+
+class TestGetShare:
+    """Test suite for ShareService.get_share."""
+
+    def test_get_share_success(self, share_service, dynamodb_stubber, s3_stubber):
+        """Get share returns metadata and download URL."""
+        share_id = "test-share-123"
+        item_id = "test-item-456"
+        vault_id = "test-vault-789"
+        client_ip = "1.2.3.4"
+
+        # Stub rate limit check (get_item returns no existing rate row)
+        dynamodb_stubber.add_response(
+            "get_item",
+            {},
+            {"TableName": "test-shares-table", "Key": ANY},
+        )
+
+        # Stub rate limit put (create/update rate row)
+        dynamodb_stubber.add_response(
+            "put_item",
+            {},
+            {"TableName": "test-shares-table", "Item": ANY},
+        )
+
+        # Stub get share metadata
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"SHARE#{share_id}"},
+                    "SK": {"S": "METADATA"},
+                    "share_id": {"S": share_id},
+                    "item_id": {"S": item_id},
+                    "vault_id": {"S": vault_id},
+                    "user_id": {"S": "owner"},
+                    "created_at": {"N": str(int(time.time()))},
+                    "is_revoked": {"BOOL": False},
+                    "access_count": {"N": "0"},
+                }
+            },
+            {"TableName": "test-shares-table", "Key": ANY},
+        )
+
+        # Stub get item (to find s3_key)
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"ITEM#{item_id}"},
+                    "SK": {"S": "METADATA"},
+                    "item_id": {"S": item_id},
+                    "vault_id": {"S": vault_id},
+                    "user_id": {"S": "owner"},
+                    "item_type": {"S": "MEDIA"},
+                    "s3_key": {"S": f"vaults/{vault_id}/{item_id}"},
+                    "upload_status": {"S": "COMPLETE"},
+                    "encrypted_metadata": {"B": b"encrypted"},
+                    "created_at": {"N": str(int(time.time()))},
+                }
+            },
+            {"TableName": "test-items-table", "Key": ANY},
+        )
+
+        # Stub update access count
+        dynamodb_stubber.add_response(
+            "update_item",
+            {},
+            {
+                "TableName": "test-shares-table",
+                "Key": ANY,
+                "UpdateExpression": ANY,
+                "ExpressionAttributeValues": ANY,
+            },
+        )
+
+        response = share_service.get_share(share_id, client_ip)
+
+        assert response.share_id == share_id
+        assert response.item_id == item_id
+        assert response.download_url is not None
+        assert response.url_expires_at > 0
+
+    def test_get_share_revoked(self, share_service, dynamodb_stubber):
+        """Get revoked share raises error."""
+        share_id = "test-share-123"
+        client_ip = "1.2.3.4"
+
+        # Stub rate limit check
+        dynamodb_stubber.add_response("get_item", {}, {"TableName": "test-shares-table", "Key": ANY})
+        dynamodb_stubber.add_response("put_item", {}, {"TableName": "test-shares-table", "Item": ANY})
+
+        # Stub get share metadata - revoked
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"SHARE#{share_id}"},
+                    "SK": {"S": "METADATA"},
+                    "share_id": {"S": share_id},
+                    "item_id": {"S": "item"},
+                    "vault_id": {"S": "vault"},
+                    "user_id": {"S": "owner"},
+                    "created_at": {"N": str(int(time.time()))},
+                    "is_revoked": {"BOOL": True},
+                    "access_count": {"N": "0"},
+                }
+            },
+            {"TableName": "test-shares-table", "Key": ANY},
+        )
+
+        with pytest.raises(Exception, match="revoked"):
+            share_service.get_share(share_id, client_ip)
+
+    def test_get_share_expired(self, share_service, dynamodb_stubber):
+        """Get expired share raises error."""
+        share_id = "test-share-123"
+        client_ip = "1.2.3.4"
+
+        # Stub rate limit check
+        dynamodb_stubber.add_response("get_item", {}, {"TableName": "test-shares-table", "Key": ANY})
+        dynamodb_stubber.add_response("put_item", {}, {"TableName": "test-shares-table", "Item": ANY})
+
+        # Stub get share metadata - expired
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"SHARE#{share_id}"},
+                    "SK": {"S": "METADATA"},
+                    "share_id": {"S": share_id},
+                    "item_id": {"S": "item"},
+                    "vault_id": {"S": "vault"},
+                    "user_id": {"S": "owner"},
+                    "created_at": {"N": str(int(time.time()) - 86400)},
+                    "expires_at": {"N": str(int(time.time()) - 3600)},
+                    "is_revoked": {"BOOL": False},
+                    "access_count": {"N": "0"},
+                }
+            },
+            {"TableName": "test-shares-table", "Key": ANY},
+        )
+
+        with pytest.raises(Exception, match="expired"):
+            share_service.get_share(share_id, client_ip)
+
+
+class TestRevokeShare:
+    """Test suite for ShareService.revoke_share."""
+
+    def test_revoke_share_success(self, share_service, dynamodb_stubber):
+        """Revoke share sets is_revoked and TTL."""
+        share_id = "test-share-123"
+        user_id = "test-user-123"
+
+        # Stub get share metadata
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"SHARE#{share_id}"},
+                    "SK": {"S": "METADATA"},
+                    "share_id": {"S": share_id},
+                    "item_id": {"S": "item"},
+                    "vault_id": {"S": "vault"},
+                    "user_id": {"S": user_id},
+                    "created_at": {"N": str(int(time.time()))},
+                    "is_revoked": {"BOOL": False},
+                    "access_count": {"N": "0"},
+                }
+            },
+            {"TableName": "test-shares-table", "Key": ANY},
+        )
+
+        # Stub update item (set revoked + TTL)
+        dynamodb_stubber.add_response(
+            "update_item",
+            {},
+            {
+                "TableName": "test-shares-table",
+                "Key": ANY,
+                "UpdateExpression": ANY,
+                "ExpressionAttributeValues": ANY,
+            },
+        )
+
+        response = share_service.revoke_share(user_id, share_id)
+
+        assert response.message == "Share revoked successfully"
+        assert response.revoked_at > 0
+
+    def test_revoke_share_wrong_owner(self, share_service, dynamodb_stubber):
+        """Revoke share fails if user doesn't own it."""
+        share_id = "test-share-123"
+
+        # Stub get share metadata - different owner
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"SHARE#{share_id}"},
+                    "SK": {"S": "METADATA"},
+                    "share_id": {"S": share_id},
+                    "item_id": {"S": "item"},
+                    "vault_id": {"S": "vault"},
+                    "user_id": {"S": "other-user"},
+                    "created_at": {"N": str(int(time.time()))},
+                    "is_revoked": {"BOOL": False},
+                    "access_count": {"N": "0"},
+                }
+            },
+            {"TableName": "test-shares-table", "Key": ANY},
+        )
+
+        with pytest.raises(Exception, match="not found"):
+            share_service.revoke_share("test-user-123", share_id)
+```
+
+### Step 3: Add share_service fixture to conftest.py
+
+Modify `lambda/tests/conftest.py` - add import and fixture:
+
+```python
+from src.api.services.share_service import ShareService
+
+@pytest.fixture
+def share_service(boto_session, shares_table_name, items_table_name, files_bucket_name):
+    """Create a ShareService instance for testing."""
+    return ShareService(
+        session=boto_session,
+        shares_table_name=shares_table_name,
+        items_table_name=items_table_name,
+        s3_bucket_name=files_bucket_name,
+    )
+```
+
+### Step 4: Run tests to verify they fail
+
+Run: `cd /Users/lcmessen/cortex/lambda && python -m pytest tests/unit/services/test_share_service.py -v`
+Expected: FAIL with "No module named 'src.api.services.share_service'"
+
+### Step 5: Write ShareService implementation
+
+Create `lambda/src/api/services/share_service.py`:
+
+```python
+"""
+Share service layer for Cortex API.
+
+This module implements business logic for file sharing operations including
+share creation, access, revocation, and rate limiting.
+
+Requirements: 17.3, 17.4, 17.5, 18.1, 18.2, 18.5, 18.6, 18.7, 18.9, 31.5
+"""
+
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import boto3
+from aws_lambda_powertools import Logger
+from aws_lambda_powertools.event_handler.exceptions import (
+    BadRequestError,
+    NotFoundError,
+    ServiceError,
+)
+
+from src.shared.models import (
+    CreateShareRequest,
+    CreateShareResponse,
+    GetShareResponse,
+    RevokeShareResponse,
+)
+from src.shared.repository import DynamoDBRepository, S3Repository, build_s3_key
+
+logger = Logger(child=True)
+
+PRESIGNED_URL_EXPIRATION = 900  # 15 minutes
+RATE_LIMIT_MAX_ATTEMPTS = 5
+RATE_LIMIT_WINDOW_SECONDS = 3600  # 1 hour
+TTL_GRACE_PERIOD = 86400  # 24 hours after expiration
+TTL_REVOKED_CLEANUP = 604800  # 7 days after revocation
+TTL_RATE_LIMIT_CLEANUP = 7200  # 2 hours after window
+
+
+class ShareRevokedError(ServiceError):
+    """Share has been revoked."""
+
+    def __init__(self, msg: str = "Share has been revoked"):
+        super().__init__(status_code=410, msg=msg)
+
+
+class ShareExpiredError(ServiceError):
+    """Share has expired."""
+
+    def __init__(self, msg: str = "Share has expired"):
+        super().__init__(status_code=410, msg=msg)
+
+
+class RateLimitExceededError(ServiceError):
+    """Rate limit exceeded."""
+
+    def __init__(self, retry_after: int):
+        self.retry_after = retry_after
+        super().__init__(status_code=429, msg="Rate limit exceeded")
+
+
+class ShareService:
+    """Service layer for share operations."""
+
+    def __init__(
+        self,
+        session: boto3.Session,
+        shares_table_name: str,
+        items_table_name: str,
+        s3_bucket_name: str,
+    ):
+        self.shares_repo = DynamoDBRepository(session, shares_table_name)
+        self.items_repo = DynamoDBRepository(session, items_table_name)
+        self.s3_repo = S3Repository(session, s3_bucket_name)
+
+    def create_share(self, user_id: str, request: CreateShareRequest) -> CreateShareResponse:
+        """
+        Create a share for a file.
+
+        Verifies the user owns the item, then stores share metadata.
+        No key material is stored server-side.
+
+        Args:
+            user_id: Authenticated user ID
+            request: Share creation request
+
+        Returns:
+            CreateShareResponse with share_id and timestamps
+
+        Raises:
+            NotFoundError: If item not found or user doesn't own it
+            BadRequestError: If item is not a MEDIA type or upload incomplete
+        """
+        # Verify item exists and user owns it
+        item = self.items_repo.get_item({"PK": f"ITEM#{request.item_id}"})
+
+        if not item:
+            raise NotFoundError("Item not found")
+
+        if item["user_id"] != user_id:
+            raise NotFoundError("Item not found")
+
+        if item.get("item_type") != "MEDIA":
+            raise BadRequestError("Only MEDIA items can be shared")
+
+        if item.get("upload_status") == "PENDING":
+            raise BadRequestError("Item upload not yet complete")
+
+        share_id = str(uuid.uuid4())
+        now = int(time.time())
+
+        share_item = {
+            "PK": f"SHARE#{share_id}",
+            "SK": "METADATA",
+            "share_id": share_id,
+            "item_id": request.item_id,
+            "vault_id": item["vault_id"],
+            "user_id": user_id,
+            "created_at": now,
+            "is_revoked": False,
+            "access_count": 0,
+        }
+
+        if request.expires_at is not None:
+            share_item["expires_at"] = request.expires_at
+            share_item["ttl"] = request.expires_at + TTL_GRACE_PERIOD
+
+        # Conditional write to prevent duplicate share IDs
+        self.shares_repo.put_item(
+            share_item,
+            condition_expression="attribute_not_exists(PK)",
+        )
+
+        logger.info(
+            "Share created",
+            extra={
+                "share_id": share_id,
+                "item_id": request.item_id,
+                "user_id": user_id,
+                "has_expiration": request.expires_at is not None,
+            },
+        )
+
+        return CreateShareResponse(
+            share_id=share_id,
+            created_at=now,
+            expires_at=request.expires_at,
+        )
+
+    def get_share(self, share_id: str, client_ip: str) -> GetShareResponse:
+        """
+        Access a shared file (anonymous).
+
+        Checks rate limits, validates share state, generates presigned URL.
+
+        Args:
+            share_id: Share identifier
+            client_ip: Client IP address for rate limiting
+
+        Returns:
+            GetShareResponse with metadata and download URL
+
+        Raises:
+            NotFoundError: If share not found
+            ShareRevokedError: If share has been revoked
+            ShareExpiredError: If share has expired
+            RateLimitExceededError: If rate limit exceeded
+        """
+        # Check rate limit
+        self._check_rate_limit(share_id, client_ip)
+
+        # Fetch share metadata
+        share = self.shares_repo.get_item({
+            "PK": f"SHARE#{share_id}",
+            "SK": "METADATA",
+        })
+
+        if not share:
+            raise NotFoundError("Share not found")
+
+        # Check if revoked
+        if share.get("is_revoked", False):
+            raise ShareRevokedError()
+
+        # Check if expired
+        expires_at = share.get("expires_at")
+        if expires_at is not None and int(expires_at) < int(time.time()):
+            raise ShareExpiredError()
+
+        # Get item to find S3 key
+        item_id = share["item_id"]
+        item = self.items_repo.get_item({"PK": f"ITEM#{item_id}"})
+
+        if not item:
+            logger.error("Shared item not found", extra={"share_id": share_id, "item_id": item_id})
+            raise NotFoundError("Shared file no longer available")
+
+        # Generate presigned download URL
+        s3_key = item["s3_key"]
+        download_url = self.s3_repo.generate_download_url(s3_key, PRESIGNED_URL_EXPIRATION)
+
+        now = int(time.time())
+        url_expires_at = now + PRESIGNED_URL_EXPIRATION
+
+        # Update access count (best-effort, don't fail on this)
+        try:
+            self.shares_repo.update_item_conditional(
+                key={"PK": f"SHARE#{share_id}", "SK": "METADATA"},
+                update_expression="SET access_count = access_count + :inc, last_accessed_at = :now",
+                condition_expression="attribute_exists(PK)",
+                expression_attribute_values={":inc": 1, ":now": now},
+            )
+        except Exception:
+            logger.warning("Failed to update access count", extra={"share_id": share_id})
+
+        logger.info(
+            "Share accessed",
+            extra={
+                "share_id": share_id,
+                "item_id": item_id,
+                "client_ip": client_ip,
+            },
+        )
+
+        return GetShareResponse(
+            share_id=share_id,
+            item_id=item_id,
+            download_url=download_url,
+            url_expires_at=url_expires_at,
+            expires_at=int(expires_at) if expires_at is not None else None,
+        )
+
+    def revoke_share(self, user_id: str, share_id: str) -> RevokeShareResponse:
+        """
+        Revoke a share.
+
+        Sets the share as revoked and schedules TTL cleanup.
+
+        Args:
+            user_id: Authenticated user ID
+            share_id: Share to revoke
+
+        Returns:
+            RevokeShareResponse with confirmation
+
+        Raises:
+            NotFoundError: If share not found or user doesn't own it
+        """
+        share = self.shares_repo.get_item({
+            "PK": f"SHARE#{share_id}",
+            "SK": "METADATA",
+        })
+
+        if not share:
+            raise NotFoundError("Share not found")
+
+        if share["user_id"] != user_id:
+            raise NotFoundError("Share not found")
+
+        now = int(time.time())
+
+        self.shares_repo.update_item_conditional(
+            key={"PK": f"SHARE#{share_id}", "SK": "METADATA"},
+            update_expression="SET is_revoked = :revoked, revoked_at = :now, #ttl_attr = :ttl",
+            condition_expression="attribute_exists(PK)",
+            expression_attribute_values={
+                ":revoked": True,
+                ":now": now,
+                ":ttl": now + TTL_REVOKED_CLEANUP,
+            },
+            expression_attribute_names={"#ttl_attr": "ttl"},
+        )
+
+        logger.info(
+            "Share revoked",
+            extra={"share_id": share_id, "user_id": user_id},
+        )
+
+        return RevokeShareResponse(
+            message="Share revoked successfully",
+            revoked_at=now,
+        )
+
+    def _check_rate_limit(self, share_id: str, client_ip: str) -> None:
+        """
+        Check and enforce rate limiting per IP per share per hour.
+
+        Args:
+            share_id: Share identifier
+            client_ip: Client IP address
+
+        Raises:
+            RateLimitExceededError: If rate limit exceeded (HTTP 429)
+        """
+        now = int(time.time())
+        window_start = now - (now % RATE_LIMIT_WINDOW_SECONDS)  # Floor to hour
+
+        rate_key = {
+            "PK": f"SHARE#{share_id}",
+            "SK": f"RATE#{client_ip}",
+        }
+
+        rate_item = self.shares_repo.get_item(rate_key)
+
+        if rate_item and int(rate_item.get("window_start", 0)) == window_start:
+            attempt_count = int(rate_item.get("attempt_count", 0))
+            if attempt_count >= RATE_LIMIT_MAX_ATTEMPTS:
+                retry_after = window_start + RATE_LIMIT_WINDOW_SECONDS - now
+                logger.warning(
+                    "Rate limit exceeded",
+                    extra={
+                        "share_id": share_id,
+                        "client_ip": client_ip,
+                        "attempt_count": attempt_count,
+                    },
+                )
+                raise RateLimitExceededError(retry_after=retry_after)
+
+        # Increment or create rate limit entry
+        self.shares_repo.put_item({
+            "PK": f"SHARE#{share_id}",
+            "SK": f"RATE#{client_ip}",
+            "attempt_count": (int(rate_item.get("attempt_count", 0)) + 1)
+            if rate_item and int(rate_item.get("window_start", 0)) == window_start
+            else 1,
+            "window_start": window_start,
+            "ttl": window_start + TTL_RATE_LIMIT_CLEANUP,
+        })
+```
+
+### Step 6: Run tests to verify they pass
+
+Run: `cd /Users/lcmessen/cortex/lambda && python -m pytest tests/unit/services/test_share_service.py -v`
+Expected: All tests PASS
+
+### Step 7: Commit
+
+```bash
+git add lambda/src/api/services/share_service.py lambda/src/shared/models.py lambda/tests/unit/services/test_share_service.py lambda/tests/conftest.py
+git commit -m "feat: add share service layer with rate limiting and TTL"
+```
+
+---
+
+## Task 3: Share Route Handlers
+
+**Files:**
+- Modify: `lambda/src/api/routes/shares.py` (replace stubs)
+- Modify: `lambda/src/environment/service_provider.py` (wire up ShareService)
+- Modify: `lambda/tests/unit/routes/test_share_routes.py` (replace stub tests)
+
+### Step 1: Write the failing route tests
+
+Replace `lambda/tests/unit/routes/test_share_routes.py` with:
+
+```python
+"""
+Unit tests for share route handlers.
+
+Tests verify that share routes work correctly through the lambda handler entrypoint.
+"""
+
+import json
+import time
+
+import pytest
+from botocore.stub import ANY
+
+from src.entrypoint.api import lambda_handler
+
+
+class TestCreateShareRoute:
+    """Test suite for CreateShareRoute through lambda handler."""
+
+    def test_create_share_route_handler(self, mock_service_provider, dynamodb_stubber):
+        """Test create share returns share_id and timestamps."""
+        user_id = "test-user-123"
+        item_id = "test-item-456"
+
+        # Stub get_item for item lookup
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"ITEM#{item_id}"},
+                    "SK": {"S": "METADATA"},
+                    "item_id": {"S": item_id},
+                    "vault_id": {"S": "vault-123"},
+                    "user_id": {"S": user_id},
+                    "item_type": {"S": "MEDIA"},
+                    "s3_key": {"S": f"vaults/vault-123/{item_id}"},
+                    "upload_status": {"S": "COMPLETE"},
+                    "encrypted_metadata": {"B": b"encrypted"},
+                    "created_at": {"N": str(int(time.time()))},
+                }
+            },
+            {"TableName": "test-items-table", "Key": ANY},
+        )
+
+        # Stub put_item for share creation
+        dynamodb_stubber.add_response(
+            "put_item",
+            {},
+            {"TableName": "test-shares-table", "Item": ANY, "ConditionExpression": ANY},
+        )
+
+        event = {
+            "resource": "/v1/shares",
+            "path": "/v1/shares",
+            "httpMethod": "POST",
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps({"item_id": item_id}),
+            "requestContext": {
+                "requestId": "test-request-id",
+                "authorizer": {"claims": {"sub": user_id}},
+            },
+        }
+
+        response = lambda_handler(event, {}, mock_service_provider)
+
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        assert "share_id" in body
+        assert "created_at" in body
+
+
+class TestGetShareRoute:
+    """Test suite for GetShareRoute through lambda handler."""
+
+    def test_get_share_route_handler(self, mock_service_provider, dynamodb_stubber):
+        """Test get share returns metadata and download URL."""
+        share_id = "test-share-123"
+        item_id = "test-item-456"
+
+        # Stub rate limit check
+        dynamodb_stubber.add_response("get_item", {}, {"TableName": "test-shares-table", "Key": ANY})
+        dynamodb_stubber.add_response("put_item", {}, {"TableName": "test-shares-table", "Item": ANY})
+
+        # Stub get share metadata
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"SHARE#{share_id}"},
+                    "SK": {"S": "METADATA"},
+                    "share_id": {"S": share_id},
+                    "item_id": {"S": item_id},
+                    "vault_id": {"S": "vault-123"},
+                    "user_id": {"S": "owner"},
+                    "created_at": {"N": str(int(time.time()))},
+                    "is_revoked": {"BOOL": False},
+                    "access_count": {"N": "0"},
+                }
+            },
+            {"TableName": "test-shares-table", "Key": ANY},
+        )
+
+        # Stub get item
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"ITEM#{item_id}"},
+                    "SK": {"S": "METADATA"},
+                    "item_id": {"S": item_id},
+                    "vault_id": {"S": "vault-123"},
+                    "user_id": {"S": "owner"},
+                    "item_type": {"S": "MEDIA"},
+                    "s3_key": {"S": f"vaults/vault-123/{item_id}"},
+                    "upload_status": {"S": "COMPLETE"},
+                    "encrypted_metadata": {"B": b"encrypted"},
+                    "created_at": {"N": str(int(time.time()))},
+                }
+            },
+            {"TableName": "test-items-table", "Key": ANY},
+        )
+
+        # Stub update access count
+        dynamodb_stubber.add_response(
+            "update_item",
+            {},
+            {
+                "TableName": "test-shares-table",
+                "Key": ANY,
+                "UpdateExpression": ANY,
+                "ExpressionAttributeValues": ANY,
+            },
+        )
+
+        event = {
+            "resource": "/v1/shares/{share_id}",
+            "path": f"/v1/shares/{share_id}",
+            "httpMethod": "GET",
+            "headers": {"Content-Type": "application/json"},
+            "pathParameters": {"share_id": share_id},
+            "requestContext": {
+                "requestId": "test-request-id",
+                "identity": {"sourceIp": "1.2.3.4"},
+            },
+        }
+
+        response = lambda_handler(event, {}, mock_service_provider)
+
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        assert body["share_id"] == share_id
+        assert "download_url" in body
+
+
+class TestRevokeShareRoute:
+    """Test suite for RevokeShareRoute through lambda handler."""
+
+    def test_revoke_share_route_handler(self, mock_service_provider, dynamodb_stubber):
+        """Test revoke share returns confirmation."""
+        share_id = "test-share-123"
+        user_id = "test-user-123"
+
+        # Stub get share metadata
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"SHARE#{share_id}"},
+                    "SK": {"S": "METADATA"},
+                    "share_id": {"S": share_id},
+                    "item_id": {"S": "item"},
+                    "vault_id": {"S": "vault"},
+                    "user_id": {"S": user_id},
+                    "created_at": {"N": str(int(time.time()))},
+                    "is_revoked": {"BOOL": False},
+                    "access_count": {"N": "0"},
+                }
+            },
+            {"TableName": "test-shares-table", "Key": ANY},
+        )
+
+        # Stub update item
+        dynamodb_stubber.add_response(
+            "update_item",
+            {},
+            {
+                "TableName": "test-shares-table",
+                "Key": ANY,
+                "UpdateExpression": ANY,
+                "ExpressionAttributeValues": ANY,
+                "ExpressionAttributeNames": ANY,
+            },
+        )
+
+        event = {
+            "resource": "/v1/shares/{share_id}",
+            "path": f"/v1/shares/{share_id}",
+            "httpMethod": "DELETE",
+            "headers": {"Content-Type": "application/json"},
+            "pathParameters": {"share_id": share_id},
+            "requestContext": {
+                "requestId": "test-request-id",
+                "authorizer": {"claims": {"sub": user_id}},
+            },
+        }
+
+        response = lambda_handler(event, {}, mock_service_provider)
+
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        assert body["message"] == "Share revoked successfully"
+        assert "revoked_at" in body
+```
+
+### Step 2: Run tests to verify they fail
+
+Run: `cd /Users/lcmessen/cortex/lambda && python -m pytest tests/unit/routes/test_share_routes.py -v`
+Expected: FAIL (stubs return placeholder response, not real data)
+
+### Step 3: Replace share route stubs with real implementation
+
+Replace `lambda/src/api/routes/shares.py`:
+
+```python
+"""
+File sharing route handlers for Cortex API.
+
+This module implements sharing-related endpoints including share creation,
+access, and revocation.
+
+Requirements: 17.3, 17.4, 17.5, 18.2, 18.5
+"""
+
+from aws_lambda_powertools import Logger
+from aws_lambda_powertools.event_handler import APIGatewayRestResolver
+from aws_lambda_powertools.event_handler.exceptions import BadRequestError
+from pydantic import ValidationError as PydanticValidationError
+
+from src.api.routes.base_route import BaseRoute
+from src.api.services.share_service import ShareService
+from src.shared.auth import get_user_from_context
+from src.shared.models import CreateShareRequest
+
+logger = Logger(child=True)
+
+
+class CreateShareRoute(BaseRoute):
+    """Handle share creation."""
+
+    def __init__(self, share_service: ShareService):
+        self.share_service = share_service
+
+    def register(self, app: APIGatewayRestResolver) -> None:
+        @app.post("/v1/shares")
+        def handle():
+            """
+            Create share metadata for a file.
+
+            The client handles all encryption. Server only stores
+            metadata (share ID, item reference, timestamps).
+            No key material is stored.
+
+            Requirements: 17.4, 17.5
+            """
+            try:
+                body = app.current_event.json_body
+                request = CreateShareRequest(**body)
+            except PydanticValidationError as e:
+                logger.warning("Request validation failed", extra={"errors": e.errors()})
+                raise BadRequestError("Invalid request format")
+
+            user_id = get_user_from_context(app.current_event)
+
+            response = self.share_service.create_share(user_id, request)
+
+            logger.info(
+                "Share created successfully",
+                extra={
+                    "user_id": user_id,
+                    "share_id": response.share_id,
+                },
+            )
+
+            return {
+                "share_id": response.share_id,
+                "created_at": response.created_at,
+                "expires_at": response.expires_at,
+            }
+
+
+class GetShareRoute(BaseRoute):
+    """Handle share access (anonymous)."""
+
+    def __init__(self, share_service: ShareService):
+        self.share_service = share_service
+
+    def register(self, app: APIGatewayRestResolver) -> None:
+        @app.get("/v1/shares/<share_id>")
+        def handle(share_id: str):
+            """
+            Access shared file (anonymous). No authentication required.
+
+            Returns share metadata and a presigned S3 download URL.
+            Rate-limited per IP per share per hour.
+
+            Requirements: 17.5, 17.7, 18.2, 18.5
+            """
+            # Extract client IP for rate limiting
+            request_context = app.current_event.get("requestContext", {})
+            identity = request_context.get("identity", {})
+            client_ip = identity.get("sourceIp", "unknown")
+
+            response = self.share_service.get_share(share_id, client_ip)
+
+            logger.info(
+                "Share accessed successfully",
+                extra={"share_id": share_id},
+            )
+
+            return {
+                "share_id": response.share_id,
+                "item_id": response.item_id,
+                "download_url": response.download_url,
+                "url_expires_at": response.url_expires_at,
+                "expires_at": response.expires_at,
+            }
+
+
+class RevokeShareRoute(BaseRoute):
+    """Handle share revocation."""
+
+    def __init__(self, share_service: ShareService):
+        self.share_service = share_service
+
+    def register(self, app: APIGatewayRestResolver) -> None:
+        @app.delete("/v1/shares/<share_id>")
+        def handle(share_id: str):
+            """
+            Revoke a share. Requires authentication.
+
+            Sets the share as revoked and schedules TTL cleanup
+            after 7 days for audit trail.
+
+            Requirements: 18.5
+            """
+            user_id = get_user_from_context(app.current_event)
+
+            response = self.share_service.revoke_share(user_id, share_id)
+
+            logger.info(
+                "Share revoked successfully",
+                extra={"share_id": share_id, "user_id": user_id},
+            )
+
+            return {
+                "message": response.message,
+                "revoked_at": response.revoked_at,
+            }
+```
+
+### Step 4: Wire up ShareService in service_provider.py
+
+Modify `lambda/src/environment/service_provider.py`:
+
+Add import:
+```python
+from src.api.services.share_service import ShareService
+```
+
+Add service property (after `collection_service`):
+```python
+    @cached_property
+    def share_service(self):
+        """Create share service."""
+        return ShareService(
+            session=self.session,
+            shares_table_name=self.shares_table_name,
+            items_table_name=self.items_table_name,
+            s3_bucket_name=self.files_bucket_name,
+        )
+```
+
+Update share route registrations (replace lines 183-185):
+```python
+                # Share routes
+                CreateShareRoute(share_service=self.share_service),
+                GetShareRoute(share_service=self.share_service),
+                RevokeShareRoute(share_service=self.share_service),
+```
+
+### Step 5: Run tests to verify they pass
+
+Run: `cd /Users/lcmessen/cortex/lambda && python -m pytest tests/unit/routes/test_share_routes.py -v`
+Expected: All tests PASS
+
+Also run full test suite:
+Run: `cd /Users/lcmessen/cortex/lambda && python -m pytest -v`
+Expected: All tests PASS
+
+### Step 6: Commit
+
+```bash
+git add lambda/src/api/routes/shares.py lambda/src/environment/service_provider.py lambda/tests/unit/routes/test_share_routes.py
+git commit -m "feat: implement share route handlers with service injection"
+```
+
+---
+
+## Task 4: DynamoDB TTL Configuration
+
+**Files:**
+- Modify: `cdk/lib/stacks/service.ts`
+
+### Step 1: Add TTL to shares table
+
+Modify `cdk/lib/stacks/service.ts` in `createSharesTable()` method. After the existing table definition add TTL configuration:
+
+```typescript
+private createSharesTable(): TableV2 {
+    const table = new TableV2(this, "SharesTable", {
+        tableName: this.resourceName("shares"),
+        partitionKey: {
+            name: "PK",
+            type: AttributeType.STRING,
+        },
+        sortKey: {
+            name: "SK",
+            type: AttributeType.STRING,
+        },
+        timeToLiveAttribute: "ttl",
+        ...DYNAMODB_DEFAULT_PROPS,
+    });
+    return table;
+}
+```
+
+### Step 2: Verify CDK synth works
+
+Run: `cd /Users/lcmessen/cortex/cdk && npx cdk synth --quiet`
+Expected: Successful synthesis without errors
+
+### Step 3: Commit
+
+```bash
+git add cdk/lib/stacks/service.ts
+git commit -m "feat: enable DynamoDB TTL on shares table for auto-cleanup"
+```
+
+---
+
+## Task 5: Property Test for Share Keys
+
+**Files:**
+- Create: `packages/encryption/tests/property/test_share_encryption.test.ts`
+
+### Step 1: Write Property 20 test
+
+Create `packages/encryption/tests/property/test_share_encryption.test.ts`:
+
+```typescript
+/**
+ * Property-Based Tests for Share Encryption Module
+ *
+ * Property 20: Share keys enable file access without vault password
+ * Validates: Requirements 17.1, 17.4
+ */
+
+import fc from 'fast-check';
+import {
+  generateDek,
+  wrapDek,
+  unwrapDek,
+  encryptFileWithDek,
+  decryptFileWithDek,
+  DekUnwrapError,
+} from '../../src/lib/envelope-encryption';
+import {
+  deriveShareKeys,
+  computeShareHmac,
+  verifyShareHmac,
+  encodeShareBlob,
+  decodeShareBlob,
+} from '../../src/lib/share-encryption';
+
+describe('Share Encryption Property Tests', () => {
+  /**
+   * Feature: cortex-sharing, Property 20: Share keys enable file access without vault password
+   *
+   * Validates: Requirements 17.1, 17.4
+   *
+   * End-to-end: encrypt file with vault KEK → create share (re-wrap DEK with
+   * share key) → access share with only share password (no vault KEK) →
+   * decrypt file → content matches original.
+   */
+  test('Property 20: Share keys enable file access without vault password', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.uint8Array({ minLength: 1, maxLength: 10000 }),  // file content
+        fc.uint8Array({ minLength: 32, maxLength: 32 }),     // vault KEK
+        fc.string({ minLength: 16, maxLength: 64 }),         // share password
+        async (fileContent, vaultKek, sharePassword) => {
+          // === OWNER: Encrypt file with vault KEK ===
+          const { encryptedContent, wrappedDek } = await encryptFileWithDek(fileContent, vaultKek);
+
+          // === OWNER: Create share ===
+          const salt = crypto.getRandomValues(new Uint8Array(16));
+          const { encryptionKey: shareKey } = await deriveShareKeys(sharePassword, salt);
+
+          // Unwrap DEK with vault KEK, re-wrap with share key
+          const dek = unwrapDek(wrappedDek, vaultKek);
+          const shareWrappedDek = await wrapDek(dek, shareKey);
+          dek.fill(0); // Zero DEK after use
+
+          // === RECIPIENT: Access share (NO vault KEK used) ===
+          const { encryptionKey: recipientShareKey } = await deriveShareKeys(sharePassword, salt);
+
+          // Unwrap DEK with share key
+          const recipientDek = unwrapDek(shareWrappedDek, recipientShareKey);
+
+          // Decrypt file content using raw DEK (not via decryptFileWithDek since
+          // wrappedDek was wrapped with share key, not vault KEK)
+          const { chacha20poly1305 } = await import('@noble/ciphers/chacha');
+          const nonce = encryptedContent.slice(0, 12);
+          const ciphertext = encryptedContent.slice(12);
+          const cipher = chacha20poly1305(recipientDek, nonce);
+          const decrypted = cipher.decrypt(ciphertext);
+          recipientDek.fill(0); // Zero DEK after use
+
+          // Verify decrypted content matches original
+          expect(decrypted).toEqual(fileContent);
+        }
+      ),
+      { numRuns: 50 }
+    );
+  });
+
+  /**
+   * Property 20b: Wrong share password fails to unwrap DEK
+   */
+  test('Property 20b: Wrong share password cannot unwrap DEK', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.uint8Array({ minLength: 32, maxLength: 32 }),     // vault KEK
+        fc.string({ minLength: 16, maxLength: 64 }),         // correct password
+        fc.string({ minLength: 16, maxLength: 64 }),         // wrong password
+        async (vaultKek, correctPassword, wrongPassword) => {
+          if (correctPassword === wrongPassword) return true;
+
+          const salt = crypto.getRandomValues(new Uint8Array(16));
+          const { encryptionKey: shareKey } = await deriveShareKeys(correctPassword, salt);
+
+          // Wrap a DEK with share key
+          const dek = await generateDek();
+          const shareWrappedDek = await wrapDek(dek, shareKey);
+          dek.fill(0);
+
+          // Try to unwrap with wrong password
+          const { encryptionKey: wrongKey } = await deriveShareKeys(wrongPassword, salt);
+          expect(() => unwrapDek(shareWrappedDek, wrongKey)).toThrow(DekUnwrapError);
+
+          return true;
+        }
+      ),
+      { numRuns: 50 }
+    );
+  });
+
+  /**
+   * Property 20c: HMAC verification catches metadata tampering
+   */
+  test('Property 20c: HMAC detects metadata tampering', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string({ minLength: 16, maxLength: 64 }),         // password
+        fc.string({ minLength: 1, maxLength: 50 }),          // correct shareId
+        fc.string({ minLength: 1, maxLength: 50 }),          // tampered shareId
+        fc.integer({ min: 1000000000, max: 2000000000 }),    // expiresAt
+        async (password, correctShareId, tamperedShareId, expiresAt) => {
+          if (correctShareId === tamperedShareId) return true;
+
+          const salt = crypto.getRandomValues(new Uint8Array(16));
+          const { hmacKey } = await deriveShareKeys(password, salt);
+
+          const mac = computeShareHmac(hmacKey, correctShareId, expiresAt);
+
+          // Verification with correct metadata succeeds
+          expect(verifyShareHmac(hmacKey, correctShareId, expiresAt, mac)).toBe(true);
+
+          // Verification with tampered shareId fails
+          expect(verifyShareHmac(hmacKey, tamperedShareId, expiresAt, mac)).toBe(false);
+
+          return true;
+        }
+      ),
+      { numRuns: 50 }
+    );
+  });
+
+  /**
+   * Property 20d: Blob encode/decode round-trip
+   */
+  test('Property 20d: Share blob encode/decode round-trip', () => {
+    fc.assert(
+      fc.property(
+        fc.uint8Array({ minLength: 16, maxLength: 16 }),  // salt
+        fc.uint8Array({ minLength: 65, maxLength: 65 }),  // wrappedDek
+        fc.uint8Array({ minLength: 32, maxLength: 32 }),  // hmac
+        (salt, wrappedDek, hmacVal) => {
+          const encoded = encodeShareBlob(1, salt, wrappedDek, hmacVal);
+          const decoded = decodeShareBlob(encoded);
+
+          expect(decoded.version).toBe(1);
+          expect(decoded.salt).toEqual(salt);
+          expect(decoded.wrappedDek).toEqual(wrappedDek);
+          expect(decoded.hmac).toEqual(hmacVal);
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+});
+```
+
+### Step 2: Run tests to verify they pass
+
+Run: `cd /Users/lcmessen/cortex && npx --workspace=packages/encryption jest tests/property/test_share_encryption.test.ts`
+Expected: All tests PASS (these test against already-written implementation from Task 1)
+
+### Step 3: Commit
+
+```bash
+git add packages/encryption/tests/property/test_share_encryption.test.ts
+git commit -m "feat: add property test 20 - share keys enable file access without vault password"
+```
+
+---
+
+## Task 6: Frontend Share Components
+
+**Files:**
+- Create: `packages/web/src/components/ShareCreate.tsx`
+- Create: `packages/web/src/components/ShareAccess.tsx`
+- Modify: `packages/web/src/App.tsx`
+
+### Step 1: Create ShareCreate component
+
+Create `packages/web/src/components/ShareCreate.tsx`:
+
+```tsx
+import { useState } from 'react';
+import {
+  deriveShareKeys,
+  computeShareHmac,
+  encodeShareBlob,
+} from '@cortex/encryption';
+import { unwrapDek, wrapDek } from '@cortex/encryption';
+
+interface ShareCreateProps {
+  itemId: string;
+  wrappedDek: Uint8Array;
+  vaultKek: Uint8Array;
+  apiBaseUrl: string;
+}
+
+export function ShareCreate({ itemId, wrappedDek, vaultKek, apiBaseUrl }: ShareCreateProps) {
+  const [password, setPassword] = useState('');
+  const [expiresIn, setExpiresIn] = useState<number | null>(null);
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const [shareId, setShareId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const passwordValid = password.length >= 16;
+
+  const handleCreateShare = async () => {
+    if (!passwordValid) return;
+    setLoading(true);
+    setError(null);
+
+    try {
+      // 1. Generate salt and derive share keys
+      const salt = crypto.getRandomValues(new Uint8Array(16));
+      const { encryptionKey, hmacKey } = await deriveShareKeys(password, salt);
+
+      // 2. Unwrap file's DEK with vault KEK, re-wrap with share key
+      const dek = unwrapDek(wrappedDek, vaultKek);
+      const shareWrappedDek = await wrapDek(dek, encryptionKey);
+      dek.fill(0);
+
+      // 3. POST share metadata to server
+      const expiresAt = expiresIn ? Math.floor(Date.now() / 1000) + expiresIn : undefined;
+      const res = await fetch(`${apiBaseUrl}/v1/shares`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ item_id: itemId, expires_at: expiresAt }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.message || 'Failed to create share');
+
+      // 4. Compute HMAC over share metadata
+      const mac = computeShareHmac(hmacKey, data.share_id, expiresAt);
+
+      // 5. Encode blob and construct URL
+      const blob = encodeShareBlob(1, salt, shareWrappedDek, mac);
+      const url = `${window.location.origin}/s/${data.share_id}#${blob}`;
+
+      setShareUrl(url);
+      setShareId(data.share_id);
+
+      // Zero sensitive material
+      encryptionKey.fill(0);
+      hmacKey.fill(0);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create share');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (shareUrl) {
+    return (
+      <div>
+        <h3>Share Link Created</h3>
+        <input readOnly value={shareUrl} style={{ width: '100%' }} onClick={e => (e.target as HTMLInputElement).select()} />
+        <button onClick={() => navigator.clipboard.writeText(shareUrl)}>Copy Link</button>
+        <p><strong>Share ID:</strong> {shareId}</p>
+        <p><strong>Warning:</strong> Do not use URL shorteners — they expose the encryption key to the shortener service.</p>
+        <p>If the link gets truncated, the recipient can enter the Share ID and password manually at /s</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h3>Share File</h3>
+      <div>
+        <label>Share Password (minimum 16 characters)</label>
+        <input
+          type="password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          placeholder="Enter a strong password..."
+        />
+        {password.length > 0 && !passwordValid && (
+          <p style={{ color: 'red' }}>Password must be at least 16 characters</p>
+        )}
+      </div>
+      <div>
+        <label>Expires In</label>
+        <select value={expiresIn ?? ''} onChange={e => setExpiresIn(e.target.value ? Number(e.target.value) : null)}>
+          <option value="">Never</option>
+          <option value={3600}>1 hour</option>
+          <option value={86400}>1 day</option>
+          <option value={604800}>7 days</option>
+          <option value={2592000}>30 days</option>
+        </select>
+      </div>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <button onClick={handleCreateShare} disabled={!passwordValid || loading}>
+        {loading ? 'Creating...' : 'Create Share Link'}
+      </button>
+    </div>
+  );
+}
+```
+
+### Step 2: Create ShareAccess component
+
+Create `packages/web/src/components/ShareAccess.tsx`:
+
+```tsx
+import { useState, useEffect } from 'react';
+import {
+  deriveShareKeys,
+  verifyShareHmac,
+  decodeShareBlob,
+} from '@cortex/encryption';
+import { unwrapDek, DekUnwrapError } from '@cortex/encryption';
+import { chacha20poly1305 } from '@noble/ciphers/chacha';
+
+interface ShareAccessProps {
+  apiBaseUrl: string;
+}
+
+export function ShareAccess({ apiBaseUrl }: ShareAccessProps) {
+  const [shareId, setShareId] = useState('');
+  const [blob, setBlob] = useState<string | null>(null);
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [failCount, setFailCount] = useState(0);
+
+  // Extract shareId and blob from URL on mount
+  useEffect(() => {
+    const path = window.location.pathname;
+    const match = path.match(/^\/s\/(.+)$/);
+    if (match) setShareId(match[1]);
+
+    const fragment = window.location.hash.slice(1);
+    if (fragment) setBlob(fragment);
+  }, []);
+
+  const handleAccess = async () => {
+    if (!shareId || !password) return;
+
+    // Client-side rate limiting: exponential backoff after 3 failures
+    if (failCount >= 3) {
+      const delay = Math.min(1000 * Math.pow(2, failCount - 3), 30000);
+      setError(`Too many attempts. Please wait ${Math.ceil(delay / 1000)} seconds.`);
+      await new Promise(r => setTimeout(r, delay));
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      let blobData: { version: number; salt: Uint8Array; wrappedDek: Uint8Array; hmac: Uint8Array };
+
+      if (blob) {
+        blobData = decodeShareBlob(blob);
+      } else {
+        setError('No share data found. The link may have been truncated. Please enter the share ID and password.');
+        setLoading(false);
+        return;
+      }
+
+      // 1. Fetch share metadata from server
+      const res = await fetch(`${apiBaseUrl}/v1/shares/${shareId}`);
+      if (res.status === 429) {
+        setError('Rate limit exceeded. Please try again later.');
+        setLoading(false);
+        return;
+      }
+      if (res.status === 410) {
+        const data = await res.json();
+        setError(data.message || 'This share is no longer available.');
+        setLoading(false);
+        return;
+      }
+      if (!res.ok) throw new Error('Share not found');
+      const shareData = await res.json();
+
+      // 2. Derive keys from password
+      const { encryptionKey, hmacKey } = await deriveShareKeys(password, blobData.salt);
+
+      // 3. Verify HMAC over metadata
+      if (!verifyShareHmac(hmacKey, shareData.share_id, shareData.expires_at, blobData.hmac)) {
+        hmacKey.fill(0);
+        encryptionKey.fill(0);
+        setError('Share metadata verification failed. The link may have been tampered with.');
+        setLoading(false);
+        return;
+      }
+      hmacKey.fill(0);
+
+      // 4. Unwrap DEK
+      let dek: Uint8Array;
+      try {
+        dek = unwrapDek(blobData.wrappedDek, encryptionKey);
+      } catch (err) {
+        encryptionKey.fill(0);
+        if (err instanceof DekUnwrapError) {
+          setFailCount(c => c + 1);
+          setError('Incorrect password. Please try again.');
+          setLoading(false);
+          return;
+        }
+        throw err;
+      }
+      encryptionKey.fill(0);
+
+      // 5. Download encrypted file
+      const fileRes = await fetch(shareData.download_url);
+      if (!fileRes.ok) throw new Error('Failed to download file');
+      const encryptedContent = new Uint8Array(await fileRes.arrayBuffer());
+
+      // 6. Decrypt file
+      const nonce = encryptedContent.slice(0, 12);
+      const ciphertext = encryptedContent.slice(12);
+      const cipher = chacha20poly1305(dek, nonce);
+      const decrypted = cipher.decrypt(ciphertext);
+      dek.fill(0);
+
+      // 7. Trigger browser download
+      const blobObj = new Blob([decrypted]);
+      const url = URL.createObjectURL(blobObj);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'shared-file';
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to access share');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h2>Access Shared File</h2>
+      <div>
+        <label>Share ID</label>
+        <input value={shareId} onChange={e => setShareId(e.target.value)} placeholder="Enter share ID..." />
+      </div>
+      <div>
+        <label>Share Password</label>
+        <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Enter share password..." />
+      </div>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <button onClick={handleAccess} disabled={!shareId || !password || loading}>
+        {loading ? 'Decrypting...' : 'Access File'}
+      </button>
+    </div>
+  );
+}
+```
+
+### Step 3: Update App.tsx to route share access
+
+Modify `packages/web/src/App.tsx`:
+
+```tsx
+import { ShareAccess } from './components/ShareAccess';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+
+function App() {
+  const isShareRoute = window.location.pathname.startsWith('/s');
+
+  if (isShareRoute) {
+    return <ShareAccess apiBaseUrl={API_BASE_URL} />;
+  }
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Cortex</h1>
+      <p>Zero-Knowledge Media Backup</p>
+    </div>
+  );
+}
+
+export default App;
+```
+
+### Step 4: Verify frontend builds
+
+Run: `cd /Users/lcmessen/cortex && npm run --workspace=packages/web build`
+Expected: Build succeeds
+
+### Step 5: Commit
+
+```bash
+git add packages/web/src/components/ShareCreate.tsx packages/web/src/components/ShareAccess.tsx packages/web/src/App.tsx
+git commit -m "feat: add share creation and access frontend components"
+```
+
+---
+
+## Task 7: Update task list and final verification
+
+### Step 1: Run all backend tests
+
+Run: `cd /Users/lcmessen/cortex/lambda && python -m pytest -v`
+Expected: All tests PASS
+
+### Step 2: Run all encryption tests
+
+Run: `cd /Users/lcmessen/cortex && npx --workspace=packages/encryption jest`
+Expected: All tests PASS
+
+### Step 3: Run frontend build
+
+Run: `cd /Users/lcmessen/cortex && npm run --workspace=packages/web build`
+Expected: Build succeeds
+
+### Step 4: Update tasks.md
+
+Mark tasks 17.1-17.5 as complete in `.kiro/specs/cortex/tasks.md`:
+- `[x] 17. Implement file sharing system`
+- `[x] 17.1 Build frontend share creation with envelope encryption`
+- `[x] 17.2 Create share route handlers`
+- `[x] 17.3 Create share service layer with server-side rate limiting`
+- `[x] 17.4 Build frontend share access with envelope encryption and HMAC verification`
+- `[x] 17.5 Write property test for share keys enable file access without vault password`
+
+### Step 5: Commit
+
+```bash
+git add .kiro/specs/cortex/tasks.md
+git commit -m "docs: mark task 17 (file sharing) as complete"
+```

--- a/lambda/src/api/routes/shares.py
+++ b/lambda/src/api/routes/shares.py
@@ -9,8 +9,13 @@ Requirements: 17.3, 17.4, 17.5, 18.2, 18.5
 
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
+from aws_lambda_powertools.event_handler.exceptions import BadRequestError
+from pydantic import ValidationError as PydanticValidationError
 
 from src.api.routes.base_route import BaseRoute
+from src.api.services.share_service import ShareService
+from src.shared.auth import get_user_from_context
+from src.shared.models import CreateShareRequest
 
 logger = Logger(child=True)
 
@@ -18,20 +23,54 @@ logger = Logger(child=True)
 class CreateShareRoute(BaseRoute):
     """Handle share creation."""
 
+    def __init__(self, share_service: ShareService):
+        """Initialize the create share route."""
+        self.share_service = share_service
+
     def register(self, app: APIGatewayRestResolver) -> None:
         @app.post("/v1/shares")
         def handle():
             """
             Create item share with metadata.
 
-            This endpoint will be implemented in task 17.2.
+            Requirements: 17.3
             """
-            logger.info("Create share endpoint called")
-            return {"message": "Create share endpoint - to be implemented in task 17.2"}
+            # Pydantic validation
+            try:
+                body = app.current_event.json_body
+                request = CreateShareRequest(**body)
+            except PydanticValidationError as e:
+                logger.warning("Request validation failed", extra={"errors": e.errors()})
+                raise BadRequestError("Invalid request format")
+
+            # Extract user identity from context
+            user_id = get_user_from_context(app.current_event)
+
+            # Create share
+            response = self.share_service.create_share(user_id, request)
+
+            logger.info(
+                "Share created successfully",
+                extra={
+                    "user_id": user_id,
+                    "share_id": response.share_id,
+                    "item_id": request.item_id,
+                },
+            )
+
+            return {
+                "share_id": response.share_id,
+                "created_at": response.created_at,
+                "expires_at": response.expires_at,
+            }
 
 
 class GetShareRoute(BaseRoute):
     """Handle share access (anonymous)."""
+
+    def __init__(self, share_service: ShareService):
+        """Initialize the get share route."""
+        self.share_service = share_service
 
     def register(self, app: APIGatewayRestResolver) -> None:
         @app.get("/v1/shares/<share_id>")
@@ -42,14 +81,39 @@ class GetShareRoute(BaseRoute):
             Args:
                 share_id: Share identifier
 
-            This endpoint will be implemented in task 17.2.
+            Requirements: 17.4, 18.2
             """
-            logger.info("Get share endpoint called", extra={"share_id": share_id})
-            return {"message": "Get share endpoint - to be implemented in task 17.2"}
+            # Extract client IP from request context (no auth required)
+            request_context = app.current_event.get("requestContext", {})
+            identity = request_context.get("identity", {})
+            client_ip = identity.get("sourceIp", "unknown")
+
+            # Access share
+            response = self.share_service.get_share(share_id, client_ip)
+
+            logger.info(
+                "Share accessed successfully",
+                extra={
+                    "share_id": share_id,
+                    "client_ip": client_ip,
+                },
+            )
+
+            return {
+                "share_id": response.share_id,
+                "item_id": response.item_id,
+                "download_url": response.download_url,
+                "url_expires_at": response.url_expires_at,
+                "expires_at": response.expires_at,
+            }
 
 
 class RevokeShareRoute(BaseRoute):
     """Handle share revocation."""
+
+    def __init__(self, share_service: ShareService):
+        """Initialize the revoke share route."""
+        self.share_service = share_service
 
     def register(self, app: APIGatewayRestResolver) -> None:
         @app.delete("/v1/shares/<share_id>")
@@ -60,7 +124,23 @@ class RevokeShareRoute(BaseRoute):
             Args:
                 share_id: Share identifier
 
-            This endpoint will be implemented in task 17.2.
+            Requirements: 17.5, 18.5
             """
-            logger.info("Revoke share endpoint called", extra={"share_id": share_id})
-            return {"message": "Revoke share endpoint - to be implemented in task 17.2"}
+            # Extract user identity from context
+            user_id = get_user_from_context(app.current_event)
+
+            # Revoke share
+            response = self.share_service.revoke_share(user_id, share_id)
+
+            logger.info(
+                "Share revoked successfully",
+                extra={
+                    "user_id": user_id,
+                    "share_id": share_id,
+                },
+            )
+
+            return {
+                "message": response.message,
+                "revoked_at": response.revoked_at,
+            }

--- a/lambda/src/api/routes/shares.py
+++ b/lambda/src/api/routes/shares.py
@@ -7,6 +7,9 @@ access, and revocation.
 Requirements: 17.3, 17.4, 17.5, 18.2, 18.5
 """
 
+import hashlib
+import re
+
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.event_handler.exceptions import BadRequestError
@@ -18,6 +21,10 @@ from src.shared.auth import get_user_from_context
 from src.shared.models import CreateShareRequest
 
 logger = Logger(child=True)
+
+UUID_PATTERN = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE
+)
 
 
 class CreateShareRoute(BaseRoute):
@@ -83,6 +90,9 @@ class GetShareRoute(BaseRoute):
 
             Requirements: 17.4, 18.2
             """
+            if not UUID_PATTERN.match(share_id):
+                raise BadRequestError("Invalid share ID format")
+
             # Extract client IP from request context (no auth required)
             request_context = app.current_event.get("requestContext", {})
             identity = request_context.get("identity", {})
@@ -91,11 +101,12 @@ class GetShareRoute(BaseRoute):
             # Access share
             response = self.share_service.get_share(share_id, client_ip)
 
+            ip_hash = hashlib.sha256(client_ip.encode()).hexdigest()[:12]
             logger.info(
                 "Share accessed successfully",
                 extra={
                     "share_id": share_id,
-                    "client_ip": client_ip,
+                    "client_ip_hash": ip_hash,
                 },
             )
 
@@ -126,6 +137,9 @@ class RevokeShareRoute(BaseRoute):
 
             Requirements: 17.5, 18.5
             """
+            if not UUID_PATTERN.match(share_id):
+                raise BadRequestError("Invalid share ID format")
+
             # Extract user identity from context
             user_id = get_user_from_context(app.current_event)
 

--- a/lambda/src/api/services/share_service.py
+++ b/lambda/src/api/services/share_service.py
@@ -7,6 +7,7 @@ creating shares, accessing shared items, revoking shares, and rate limiting.
 Requirements: 6.12
 """
 
+import hashlib
 import time
 import uuid
 
@@ -28,7 +29,8 @@ logger = Logger(child=True)
 
 # Constants
 PRESIGNED_URL_EXPIRATION = 900  # 15 minutes
-RATE_LIMIT_MAX_ATTEMPTS = 5
+RATE_LIMIT_MAX_ATTEMPTS_PER_IP = 5
+RATE_LIMIT_MAX_ATTEMPTS_GLOBAL = 50
 RATE_LIMIT_WINDOW_SECONDS = 3600  # 1 hour
 TTL_GRACE_PERIOD = 86400  # 24 hours
 TTL_REVOKED_CLEANUP = 604800  # 7 days
@@ -230,12 +232,13 @@ class ShareService:
                 extra={"share_id": share_id},
             )
 
+        ip_hash = hashlib.sha256(client_ip.encode()).hexdigest()[:12]
         logger.info(
             "Share accessed",
             extra={
                 "share_id": share_id,
                 "item_id": item_id,
-                "client_ip": client_ip,
+                "client_ip_hash": ip_hash,
             },
         )
 
@@ -302,50 +305,61 @@ class ShareService:
 
     def _check_rate_limit(self, share_id: str, client_ip: str) -> None:
         """
-        Check rate limit for share access per IP per share per hour.
+        Check rate limit for share access.
 
-        Uses a DynamoDB item to track access attempts. Max 5 attempts
-        per hour per IP per share.
+        Two limits enforced atomically via DynamoDB ADD:
+        1. Per-IP: max 5 attempts per IP per share per hour
+        2. Global: max 50 attempts per share per hour (across all IPs)
 
         Args:
             share_id: Share identifier
             client_ip: Client IP address
 
         Raises:
-            RateLimitExceededError: If rate limit exceeded
+            RateLimitExceededError: If either rate limit exceeded
         """
         now = int(time.time())
-        rate_key = {"PK": f"SHARE#{share_id}", "SK": f"RATE#{client_ip}"}
+        window_start = now - (now % RATE_LIMIT_WINDOW_SECONDS)
+        window_ttl = window_start + RATE_LIMIT_WINDOW_SECONDS + TTL_RATE_LIMIT_CLEANUP
 
-        rate_item = self.shares_repo.get_item(rate_key)
+        # Atomic increment for per-IP rate limit
+        ip_key = {"PK": f"SHARE#{share_id}", "SK": f"RATE#{client_ip}#{window_start}"}
+        ip_result = self.shares_repo.update_item(
+            key=ip_key,
+            update_expression="ADD attempt_count :inc SET #ttl_attr = :ttl",
+            expression_attribute_values={":inc": 1, ":ttl": window_ttl},
+            expression_attribute_names={"#ttl_attr": "ttl"},
+        )
+        ip_count = int(ip_result.get("attempt_count", 1))
 
-        if rate_item:
-            window_start = int(rate_item.get("window_start", 0))
-            attempt_count = int(rate_item.get("attempt_count", 0))
+        if ip_count > RATE_LIMIT_MAX_ATTEMPTS_PER_IP:
+            retry_after = window_start + RATE_LIMIT_WINDOW_SECONDS - now
+            logger.warning(
+                "Per-IP rate limit exceeded",
+                extra={"share_id": share_id, "attempt_count": ip_count},
+            )
+            raise RateLimitExceededError(
+                message="Rate limit exceeded",
+                retry_after=max(retry_after, 1),
+            )
 
-            # Check if we're still within the rate limit window
-            if now - window_start < RATE_LIMIT_WINDOW_SECONDS:
-                if attempt_count >= RATE_LIMIT_MAX_ATTEMPTS:
-                    retry_after = RATE_LIMIT_WINDOW_SECONDS - (now - window_start)
-                    raise RateLimitExceededError(
-                        message="Rate limit exceeded",
-                        retry_after=max(retry_after, 1),
-                    )
+        # Atomic increment for global per-share rate limit
+        global_key = {"PK": f"SHARE#{share_id}", "SK": f"RATE#GLOBAL#{window_start}"}
+        global_result = self.shares_repo.update_item(
+            key=global_key,
+            update_expression="ADD attempt_count :inc SET #ttl_attr = :ttl",
+            expression_attribute_values={":inc": 1, ":ttl": window_ttl},
+            expression_attribute_names={"#ttl_attr": "ttl"},
+        )
+        global_count = int(global_result.get("attempt_count", 1))
 
-                # Increment attempt count
-                self.shares_repo.update_item(
-                    key=rate_key,
-                    update_expression="SET attempt_count = attempt_count + :inc",
-                    expression_attribute_values={":inc": 1},
-                )
-                return
-
-        # Create or reset rate limit entry
-        rate_limit_item = {
-            "PK": f"SHARE#{share_id}",
-            "SK": f"RATE#{client_ip}",
-            "window_start": now,
-            "attempt_count": 1,
-            "ttl": now + TTL_RATE_LIMIT_CLEANUP,
-        }
-        self.shares_repo.put_item(rate_limit_item)
+        if global_count > RATE_LIMIT_MAX_ATTEMPTS_GLOBAL:
+            retry_after = window_start + RATE_LIMIT_WINDOW_SECONDS - now
+            logger.warning(
+                "Global rate limit exceeded",
+                extra={"share_id": share_id, "attempt_count": global_count},
+            )
+            raise RateLimitExceededError(
+                message="Rate limit exceeded",
+                retry_after=max(retry_after, 1),
+            )

--- a/lambda/src/api/services/share_service.py
+++ b/lambda/src/api/services/share_service.py
@@ -9,7 +9,6 @@ Requirements: 6.12
 
 import time
 import uuid
-from typing import Optional
 
 import boto3
 from aws_lambda_powertools import Logger

--- a/lambda/src/api/services/share_service.py
+++ b/lambda/src/api/services/share_service.py
@@ -1,0 +1,352 @@
+"""
+Share service layer for Cortex API.
+
+This module implements business logic for share operations including
+creating shares, accessing shared items, revoking shares, and rate limiting.
+
+Requirements: 6.12
+"""
+
+import time
+import uuid
+from typing import Optional
+
+import boto3
+from aws_lambda_powertools import Logger
+from aws_lambda_powertools.event_handler.exceptions import (
+    NotFoundError,
+)
+
+from src.shared.models import (
+    CreateShareRequest,
+    CreateShareResponse,
+    GetShareResponse,
+    RevokeShareResponse,
+)
+from src.shared.repository import DynamoDBRepository, S3Repository
+
+logger = Logger(child=True)
+
+# Constants
+PRESIGNED_URL_EXPIRATION = 900  # 15 minutes
+RATE_LIMIT_MAX_ATTEMPTS = 5
+RATE_LIMIT_WINDOW_SECONDS = 3600  # 1 hour
+TTL_GRACE_PERIOD = 86400  # 24 hours
+TTL_REVOKED_CLEANUP = 604800  # 7 days
+TTL_RATE_LIMIT_CLEANUP = 7200  # 2 hours
+
+
+# ============================================================================
+# Custom Error Classes
+# ============================================================================
+
+
+class ServiceError(Exception):
+    """Base error class for share service errors."""
+
+    def __init__(self, message: str, status_code: int = 500):
+        self.message = message
+        self.status_code = status_code
+        super().__init__(self.message)
+
+
+class ShareRevokedError(ServiceError):
+    """Raised when attempting to access a revoked share."""
+
+    def __init__(self, message: str = "Share has been revoked"):
+        super().__init__(message=message, status_code=410)
+
+
+class ShareExpiredError(ServiceError):
+    """Raised when attempting to access an expired share."""
+
+    def __init__(self, message: str = "Share has expired"):
+        super().__init__(message=message, status_code=410)
+
+
+class RateLimitExceededError(ServiceError):
+    """Raised when rate limit is exceeded for share access."""
+
+    def __init__(self, message: str = "Rate limit exceeded", retry_after: int = 3600):
+        self.retry_after = retry_after
+        super().__init__(message=message, status_code=429)
+
+
+class ShareService:
+    """Service layer for share operations."""
+
+    def __init__(
+        self,
+        session: boto3.Session,
+        shares_table_name: str,
+        items_table_name: str,
+        s3_bucket_name: str,
+    ):
+        """
+        Initialize share service.
+
+        Args:
+            session: Boto3 session
+            shares_table_name: DynamoDB shares table name
+            items_table_name: DynamoDB items table name
+            s3_bucket_name: S3 bucket name for file storage
+        """
+        self.shares_repo = DynamoDBRepository(session, shares_table_name)
+        self.items_repo = DynamoDBRepository(session, items_table_name)
+        self.s3_repo = S3Repository(session, s3_bucket_name)
+
+    def create_share(self, user_id: str, request: CreateShareRequest) -> CreateShareResponse:
+        """
+        Create a share for an item.
+
+        Verifies the user owns the item, then stores share metadata
+        in the shares table with an optional TTL for expiration.
+
+        Args:
+            user_id: Authenticated user ID
+            request: Create share request
+
+        Returns:
+            CreateShareResponse with share ID and timestamps
+
+        Raises:
+            NotFoundError: If item not found or user doesn't own it
+        """
+        # Verify user owns the item
+        item_key = {"PK": f"ITEM#{request.item_id}"}
+        item = self.items_repo.get_item(item_key)
+
+        if not item:
+            raise NotFoundError("Item not found")
+
+        if item["user_id"] != user_id:
+            raise NotFoundError("Item not found")
+
+        # Generate share ID and timestamp
+        share_id = str(uuid.uuid4())
+        now = int(time.time())
+
+        # Build share item
+        share_item = {
+            "PK": f"SHARE#{share_id}",
+            "SK": "METADATA",
+            "share_id": share_id,
+            "item_id": request.item_id,
+            "vault_id": item.get("vault_id", ""),
+            "user_id": user_id,
+            "created_at": now,
+            "is_revoked": False,
+            "access_count": 0,
+        }
+
+        # Set expiration if provided
+        if request.expires_at is not None:
+            share_item["expires_at"] = request.expires_at
+            # Set TTL to expires_at + grace period for DynamoDB auto-cleanup
+            share_item["ttl"] = request.expires_at + TTL_GRACE_PERIOD
+
+        # Store share metadata
+        self.shares_repo.put_item(share_item)
+
+        logger.info(
+            "Created share",
+            extra={
+                "user_id": user_id,
+                "share_id": share_id,
+                "item_id": request.item_id,
+                "expires_at": request.expires_at,
+            },
+        )
+
+        return CreateShareResponse(
+            share_id=share_id,
+            created_at=now,
+            expires_at=request.expires_at,
+        )
+
+    def get_share(self, share_id: str, client_ip: str) -> GetShareResponse:
+        """
+        Access a share and generate a presigned download URL.
+
+        Checks rate limit, fetches share metadata, validates the share
+        is not revoked or expired, generates a presigned S3 URL, and
+        increments the access count.
+
+        Args:
+            share_id: Share identifier
+            client_ip: Client IP address for rate limiting
+
+        Returns:
+            GetShareResponse with download URL and metadata
+
+        Raises:
+            RateLimitExceededError: If rate limit exceeded
+            NotFoundError: If share not found
+            ShareRevokedError: If share has been revoked
+            ShareExpiredError: If share has expired
+        """
+        # Check rate limit
+        self._check_rate_limit(share_id, client_ip)
+
+        # Fetch share metadata
+        share_key = {"PK": f"SHARE#{share_id}", "SK": "METADATA"}
+        share = self.shares_repo.get_item(share_key)
+
+        if not share:
+            raise NotFoundError("Share not found")
+
+        # Check if revoked
+        if share.get("is_revoked"):
+            raise ShareRevokedError()
+
+        # Check if expired
+        now = int(time.time())
+        expires_at = share.get("expires_at")
+        if expires_at is not None and int(expires_at) <= now:
+            raise ShareExpiredError()
+
+        # Fetch item to get S3 key
+        item_id = share["item_id"]
+        item_key = {"PK": f"ITEM#{item_id}"}
+        item = self.items_repo.get_item(item_key)
+
+        if not item:
+            raise NotFoundError("Shared item no longer exists")
+
+        # Generate presigned download URL
+        s3_key = item["s3_key"]
+        download_url = self.s3_repo.generate_download_url(s3_key, PRESIGNED_URL_EXPIRATION)
+        url_expires_at = now + PRESIGNED_URL_EXPIRATION
+
+        # Increment access count (best-effort)
+        try:
+            self.shares_repo.update_item(
+                key={"PK": f"SHARE#{share_id}", "SK": "METADATA"},
+                update_expression="SET access_count = access_count + :inc, last_accessed_at = :now",
+                expression_attribute_values={":inc": 1, ":now": now},
+            )
+        except Exception:
+            logger.warning(
+                "Failed to update access count",
+                extra={"share_id": share_id},
+            )
+
+        logger.info(
+            "Share accessed",
+            extra={
+                "share_id": share_id,
+                "item_id": item_id,
+                "client_ip": client_ip,
+            },
+        )
+
+        return GetShareResponse(
+            share_id=share_id,
+            item_id=item_id,
+            download_url=download_url,
+            url_expires_at=url_expires_at,
+            expires_at=int(expires_at) if expires_at is not None else None,
+        )
+
+    def revoke_share(self, user_id: str, share_id: str) -> RevokeShareResponse:
+        """
+        Revoke a share.
+
+        Verifies the user owns the share, then sets is_revoked=True
+        and a TTL for 7-day cleanup.
+
+        Args:
+            user_id: Authenticated user ID
+            share_id: Share identifier to revoke
+
+        Returns:
+            RevokeShareResponse with confirmation
+
+        Raises:
+            NotFoundError: If share not found or user doesn't own it
+        """
+        # Fetch share metadata
+        share_key = {"PK": f"SHARE#{share_id}", "SK": "METADATA"}
+        share = self.shares_repo.get_item(share_key)
+
+        if not share:
+            raise NotFoundError("Share not found")
+
+        # Verify ownership
+        if share["user_id"] != user_id:
+            raise NotFoundError("Share not found")
+
+        # Set revoked flag and TTL for cleanup
+        now = int(time.time())
+        self.shares_repo.update_item(
+            key=share_key,
+            update_expression="SET is_revoked = :revoked, #ttl = :ttl_val",
+            expression_attribute_values={
+                ":revoked": True,
+                ":ttl_val": now + TTL_REVOKED_CLEANUP,
+            },
+            expression_attribute_names={"#ttl": "ttl"},
+        )
+
+        logger.info(
+            "Share revoked",
+            extra={
+                "user_id": user_id,
+                "share_id": share_id,
+            },
+        )
+
+        return RevokeShareResponse(
+            message="Share revoked successfully",
+            revoked_at=now,
+        )
+
+    def _check_rate_limit(self, share_id: str, client_ip: str) -> None:
+        """
+        Check rate limit for share access per IP per share per hour.
+
+        Uses a DynamoDB item to track access attempts. Max 5 attempts
+        per hour per IP per share.
+
+        Args:
+            share_id: Share identifier
+            client_ip: Client IP address
+
+        Raises:
+            RateLimitExceededError: If rate limit exceeded
+        """
+        now = int(time.time())
+        rate_key = {"PK": f"SHARE#{share_id}", "SK": f"RATE#{client_ip}"}
+
+        rate_item = self.shares_repo.get_item(rate_key)
+
+        if rate_item:
+            window_start = int(rate_item.get("window_start", 0))
+            attempt_count = int(rate_item.get("attempt_count", 0))
+
+            # Check if we're still within the rate limit window
+            if now - window_start < RATE_LIMIT_WINDOW_SECONDS:
+                if attempt_count >= RATE_LIMIT_MAX_ATTEMPTS:
+                    retry_after = RATE_LIMIT_WINDOW_SECONDS - (now - window_start)
+                    raise RateLimitExceededError(
+                        message="Rate limit exceeded",
+                        retry_after=max(retry_after, 1),
+                    )
+
+                # Increment attempt count
+                self.shares_repo.update_item(
+                    key=rate_key,
+                    update_expression="SET attempt_count = attempt_count + :inc",
+                    expression_attribute_values={":inc": 1},
+                )
+                return
+
+        # Create or reset rate limit entry
+        rate_limit_item = {
+            "PK": f"SHARE#{share_id}",
+            "SK": f"RATE#{client_ip}",
+            "window_start": now,
+            "attempt_count": 1,
+            "ttl": now + TTL_RATE_LIMIT_CLEANUP,
+        }
+        self.shares_repo.put_item(rate_limit_item)

--- a/lambda/src/environment/service_provider.py
+++ b/lambda/src/environment/service_provider.py
@@ -39,6 +39,7 @@ from src.api.services.api_router import ApiRouter
 from src.api.services.auth_service import AuthService
 from src.api.services.collection_service import CollectionService
 from src.api.services.item_service import ItemService
+from src.api.services.share_service import ShareService
 from src.api.services.vault_service import VaultService
 
 
@@ -127,6 +128,16 @@ class ServiceProvider:
             items_table_name=self.items_table_name,
         )
 
+    @cached_property
+    def share_service(self) -> ShareService:
+        """Create share service."""
+        return ShareService(
+            session=self.session,
+            shares_table_name=self.shares_table_name,
+            items_table_name=self.items_table_name,
+            s3_bucket_name=self.files_bucket_name,
+        )
+
     # API Router with all routes
     @cached_property
     def api_router(self):
@@ -180,9 +191,9 @@ class ServiceProvider:
                 # Tag routes
                 SearchTagsRoute(item_service=self.item_service, vault_service=self.vault_service),
                 # Share routes
-                CreateShareRoute(),
-                GetShareRoute(),
-                RevokeShareRoute(),
+                CreateShareRoute(share_service=self.share_service),
+                GetShareRoute(share_service=self.share_service),
+                RevokeShareRoute(share_service=self.share_service),
                 # Recovery routes (with service injection)
                 GenerateRecoveryCodesRoute(auth_service=self.auth_service),
                 ValidateRecoveryCodeRoute(auth_service=self.auth_service),

--- a/lambda/src/shared/models.py
+++ b/lambda/src/shared/models.py
@@ -410,59 +410,40 @@ class GetVaultSaltResponse(BaseModel):
 
 
 # ============================================================================
-# Share Models
+# Share Request/Response Models
 # ============================================================================
 
 
 class CreateShareRequest(BaseModel):
-    """Request model for creating a file share."""
+    """Request model for creating a share."""
 
-    file_id: str = Field(..., description="File identifier to share")
-    vault_id: str = Field(..., description="Vault ID")
-    expires_at: Optional[datetime] = Field(
-        default=None, description="Optional expiration timestamp"
-    )
-    is_password_protected: bool = Field(
-        default=False, description="Whether share requires password"
-    )
+    item_id: str = Field(..., description="Item to share")
+    expires_at: Optional[int] = Field(default=None, description="Expiration timestamp (Unix epoch)")
 
 
 class CreateShareResponse(BaseModel):
     """Response model for share creation."""
 
-    share_id: str = Field(..., description="Unique share identifier")
-    created_at: datetime = Field(..., description="Creation timestamp")
-    expires_at: Optional[datetime] = Field(default=None, description="Expiration timestamp")
-
-
-class GetShareRequest(BaseModel):
-    """Request model for accessing a share."""
-
     share_id: str = Field(..., description="Share identifier")
+    created_at: int = Field(..., description="Creation timestamp (Unix epoch)")
+    expires_at: Optional[int] = Field(default=None, description="Expiration timestamp")
 
 
 class GetShareResponse(BaseModel):
     """Response model for share access."""
 
     share_id: str = Field(..., description="Share identifier")
-    file_id: str = Field(..., description="File identifier")
-    download_url: str = Field(..., description="Presigned download URL")
-    encrypted_metadata: bytes = Field(..., description="Encrypted file metadata")
-    expires_at: datetime = Field(..., description="URL expiration")
-    is_password_protected: bool = Field(default=False, description="Whether password is required")
-
-
-class RevokeShareRequest(BaseModel):
-    """Request model for revoking a share."""
-
-    share_id: str = Field(..., description="Share identifier")
+    item_id: str = Field(..., description="Item identifier")
+    download_url: str = Field(..., description="Presigned S3 download URL")
+    url_expires_at: int = Field(..., description="URL expiration (Unix epoch)")
+    expires_at: Optional[int] = Field(default=None, description="Share expiration (Unix epoch)")
 
 
 class RevokeShareResponse(BaseModel):
     """Response model for share revocation."""
 
-    share_id: str = Field(..., description="Share identifier")
-    revoked_at: datetime = Field(..., description="Revocation timestamp")
+    message: str = Field(..., description="Confirmation message")
+    revoked_at: int = Field(..., description="Revocation timestamp (Unix epoch)")
 
 
 # ============================================================================
@@ -610,15 +591,15 @@ class DynamoDBShareItem(BaseModel):
     PK: str = Field(..., description="Partition key: SHARE#{shareId}")
     SK: str = Field(..., description="Sort key: METADATA")
     share_id: str = Field(..., description="Share identifier")
-    file_id: str = Field(..., description="File identifier")
+    item_id: str = Field(..., description="Item identifier")
     vault_id: str = Field(..., description="Vault identifier")
     user_id: str = Field(..., description="Owner user identifier")
     created_at: int = Field(..., description="Creation timestamp (Unix epoch)")
     expires_at: Optional[int] = Field(default=None, description="Expiration timestamp (Unix epoch)")
-    is_password_protected: bool = Field(default=False, description="Password protection flag")
     is_revoked: bool = Field(default=False, description="Revocation flag")
     access_count: int = Field(default=0, description="Access counter")
     last_accessed_at: Optional[int] = Field(default=None, description="Last access timestamp")
+    ttl: Optional[int] = Field(default=None, description="DynamoDB TTL for auto-cleanup")
 
 
 class DynamoDBRecoveryCodeItem(BaseModel):

--- a/lambda/tests/conftest.py
+++ b/lambda/tests/conftest.py
@@ -9,6 +9,7 @@ import pytest
 from src.api.services.auth_service import AuthService
 from src.api.services.collection_service import CollectionService
 from src.api.services.item_service import ItemService
+from src.api.services.share_service import ShareService
 from src.api.services.vault_service import VaultService
 from src.environment.service_provider import ServiceProvider
 from tests.fixtures.boto import *  # noqa: F403,F401
@@ -111,6 +112,17 @@ def item_service(boto_session, items_table_name, files_bucket_name):
     """Create an ItemService instance for testing."""
     return ItemService(
         session=boto_session,
+        items_table_name=items_table_name,
+        s3_bucket_name=files_bucket_name,
+    )
+
+
+@pytest.fixture
+def share_service(boto_session, shares_table_name, items_table_name, files_bucket_name):
+    """Create a ShareService instance for testing."""
+    return ShareService(
+        session=boto_session,
+        shares_table_name=shares_table_name,
         items_table_name=items_table_name,
         s3_bucket_name=files_bucket_name,
     )

--- a/lambda/tests/unit/routes/test_share_routes.py
+++ b/lambda/tests/unit/routes/test_share_routes.py
@@ -2,13 +2,12 @@
 Unit tests for share route handlers.
 
 Tests verify that share routes work correctly through the lambda handler entrypoint.
-
-Note: These endpoints are placeholder implementations pending task 17.2.
-Once implemented, these tests should be updated to validate actual response structures
-including share_id, share_url, expires_at, encrypted content, etc.
 """
 
 import json
+import time
+
+from botocore.stub import ANY
 
 from src.entrypoint.api import lambda_handler
 
@@ -16,15 +15,53 @@ from src.entrypoint.api import lambda_handler
 class TestCreateShareRoute:
     """Test suite for CreateShareRoute through lambda handler."""
 
-    def test_create_share_route_handler(self, mock_service_provider):
-        """Test create share route handler returns expected placeholder response."""
+    def test_create_share_route_handler(
+        self, mock_service_provider, dynamodb_stubber, items_table_name, shares_table_name
+    ):
+        """Test create share route handler returns expected response."""
+        user_id = "test-user-123"
+        item_id = "test-item-789"
+        vault_id = "test-vault-456"
+
+        # Stub 1: get_item on items table (verify user owns the item)
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"ITEM#{item_id}"},
+                    "item_id": {"S": item_id},
+                    "user_id": {"S": user_id},
+                    "vault_id": {"S": vault_id},
+                    "item_type": {"S": "MEDIA"},
+                    "s3_key": {"S": f"vaults/{vault_id}/files/{item_id}/test"},
+                }
+            },
+            expected_params={
+                "TableName": items_table_name,
+                "Key": {"PK": f"ITEM#{item_id}"},
+            },
+        )
+
+        # Stub 2: put_item on shares table (store share metadata)
+        dynamodb_stubber.add_response(
+            "put_item",
+            {},
+            {
+                "TableName": shares_table_name,
+                "Item": ANY,
+            },
+        )
+
         event = {
             "resource": "/v1/shares",
             "path": "/v1/shares",
             "httpMethod": "POST",
             "headers": {"Content-Type": "application/json"},
-            "body": json.dumps({}),
-            "requestContext": {"requestId": "test-request-id"},
+            "body": json.dumps({"item_id": item_id}),
+            "requestContext": {
+                "requestId": "test-request-id",
+                "authorizer": {"claims": {"sub": user_id}},
+            },
         }
 
         response = lambda_handler(event, {}, mock_service_provider)
@@ -34,27 +71,118 @@ class TestCreateShareRoute:
 
         # Verify response payload structure
         body = json.loads(response["body"])
-        assert "message" in body, "Response should include message"
+        assert "share_id" in body, "Response should include share_id"
+        assert "created_at" in body, "Response should include created_at"
 
-        # Verify placeholder message
-        assert isinstance(body["message"], str), "message should be a string"
-        assert "Create share endpoint" in body["message"], "Should contain placeholder text"
-        assert "to be implemented" in body["message"], "Should indicate implementation pending"
+        # Validate response values
+        assert isinstance(body["share_id"], str), "share_id should be a string"
+        assert len(body["share_id"]) > 0, "share_id should not be empty"
+        assert isinstance(body["created_at"], int), "created_at should be an integer"
 
 
 class TestGetShareRoute:
     """Test suite for GetShareRoute through lambda handler."""
 
-    def test_get_share_route_handler(self, mock_service_provider):
-        """Test get share route handler returns expected placeholder response."""
+    def test_get_share_route_handler(
+        self, mock_service_provider, dynamodb_stubber, items_table_name, shares_table_name
+    ):
+        """Test get share route handler returns expected response."""
         share_id = "test-share-123"
+        item_id = "test-item-789"
+        vault_id = "test-vault-456"
+        user_id = "test-user-123"
+        s3_key = f"vaults/{vault_id}/files/{item_id}/test"
+        now = int(time.time())
+
+        # Stub 1: get_item on shares table (rate limit check)
+        dynamodb_stubber.add_response(
+            "get_item",
+            {},  # No rate limit entry found
+            expected_params={
+                "TableName": shares_table_name,
+                "Key": {"PK": f"SHARE#{share_id}", "SK": "RATE#1.2.3.4"},
+            },
+        )
+
+        # Stub 2: put_item on shares table (create rate limit entry)
+        dynamodb_stubber.add_response(
+            "put_item",
+            {},
+            {
+                "TableName": shares_table_name,
+                "Item": ANY,
+            },
+        )
+
+        # Stub 3: get_item on shares table (fetch share metadata)
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"SHARE#{share_id}"},
+                    "SK": {"S": "METADATA"},
+                    "share_id": {"S": share_id},
+                    "item_id": {"S": item_id},
+                    "vault_id": {"S": vault_id},
+                    "user_id": {"S": user_id},
+                    "created_at": {"N": str(now)},
+                    "is_revoked": {"BOOL": False},
+                    "access_count": {"N": "0"},
+                }
+            },
+            expected_params={
+                "TableName": shares_table_name,
+                "Key": {"PK": f"SHARE#{share_id}", "SK": "METADATA"},
+            },
+        )
+
+        # Stub 4: get_item on items table (fetch item to get S3 key)
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"ITEM#{item_id}"},
+                    "item_id": {"S": item_id},
+                    "user_id": {"S": user_id},
+                    "vault_id": {"S": vault_id},
+                    "item_type": {"S": "MEDIA"},
+                    "s3_key": {"S": s3_key},
+                }
+            },
+            expected_params={
+                "TableName": items_table_name,
+                "Key": {"PK": f"ITEM#{item_id}"},
+            },
+        )
+
+        # Stub 5: update_item on shares table (increment access count)
+        dynamodb_stubber.add_response(
+            "update_item",
+            {
+                "Attributes": {
+                    "access_count": {"N": "1"},
+                    "last_accessed_at": {"N": str(now)},
+                }
+            },
+            {
+                "TableName": shares_table_name,
+                "Key": {"PK": f"SHARE#{share_id}", "SK": "METADATA"},
+                "UpdateExpression": ANY,
+                "ExpressionAttributeValues": ANY,
+                "ReturnValues": "ALL_NEW",
+            },
+        )
+
         event = {
             "resource": "/v1/shares/{share_id}",
             "path": f"/v1/shares/{share_id}",
             "httpMethod": "GET",
             "headers": {"Content-Type": "application/json"},
             "pathParameters": {"share_id": share_id},
-            "requestContext": {"requestId": "test-request-id"},
+            "requestContext": {
+                "requestId": "test-request-id",
+                "identity": {"sourceIp": "1.2.3.4"},
+            },
         }
 
         response = lambda_handler(event, {}, mock_service_provider)
@@ -64,27 +192,83 @@ class TestGetShareRoute:
 
         # Verify response payload structure
         body = json.loads(response["body"])
-        assert "message" in body, "Response should include message"
+        assert "share_id" in body, "Response should include share_id"
+        assert "item_id" in body, "Response should include item_id"
+        assert "download_url" in body, "Response should include download_url"
+        assert "url_expires_at" in body, "Response should include url_expires_at"
 
-        # Verify placeholder message
-        assert isinstance(body["message"], str), "message should be a string"
-        assert "Get share endpoint" in body["message"], "Should contain placeholder text"
-        assert "to be implemented" in body["message"], "Should indicate implementation pending"
+        # Validate response values
+        assert body["share_id"] == share_id
+        assert body["item_id"] == item_id
+        assert isinstance(body["download_url"], str), "download_url should be a string"
+        assert s3_key in body["download_url"], "download_url should contain the S3 key"
+        assert isinstance(body["url_expires_at"], int), "url_expires_at should be an integer"
 
 
 class TestRevokeShareRoute:
     """Test suite for RevokeShareRoute through lambda handler."""
 
-    def test_revoke_share_route_handler(self, mock_service_provider):
-        """Test revoke share route handler returns expected placeholder response."""
+    def test_revoke_share_route_handler(
+        self, mock_service_provider, dynamodb_stubber, shares_table_name
+    ):
+        """Test revoke share route handler returns expected response."""
         share_id = "test-share-123"
+        user_id = "test-user-123"
+        item_id = "test-item-789"
+        vault_id = "test-vault-456"
+        now = int(time.time())
+
+        # Stub 1: get_item on shares table (fetch share metadata for ownership check)
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"SHARE#{share_id}"},
+                    "SK": {"S": "METADATA"},
+                    "share_id": {"S": share_id},
+                    "item_id": {"S": item_id},
+                    "vault_id": {"S": vault_id},
+                    "user_id": {"S": user_id},
+                    "created_at": {"N": str(now)},
+                    "is_revoked": {"BOOL": False},
+                    "access_count": {"N": "0"},
+                }
+            },
+            expected_params={
+                "TableName": shares_table_name,
+                "Key": {"PK": f"SHARE#{share_id}", "SK": "METADATA"},
+            },
+        )
+
+        # Stub 2: update_item on shares table (set is_revoked and ttl)
+        dynamodb_stubber.add_response(
+            "update_item",
+            {
+                "Attributes": {
+                    "is_revoked": {"BOOL": True},
+                    "ttl": {"N": str(now + 604800)},
+                }
+            },
+            {
+                "TableName": shares_table_name,
+                "Key": {"PK": f"SHARE#{share_id}", "SK": "METADATA"},
+                "UpdateExpression": ANY,
+                "ExpressionAttributeValues": ANY,
+                "ExpressionAttributeNames": ANY,
+                "ReturnValues": "ALL_NEW",
+            },
+        )
+
         event = {
             "resource": "/v1/shares/{share_id}",
             "path": f"/v1/shares/{share_id}",
             "httpMethod": "DELETE",
             "headers": {"Content-Type": "application/json"},
             "pathParameters": {"share_id": share_id},
-            "requestContext": {"requestId": "test-request-id"},
+            "requestContext": {
+                "requestId": "test-request-id",
+                "authorizer": {"claims": {"sub": user_id}},
+            },
         }
 
         response = lambda_handler(event, {}, mock_service_provider)
@@ -95,8 +279,8 @@ class TestRevokeShareRoute:
         # Verify response payload structure
         body = json.loads(response["body"])
         assert "message" in body, "Response should include message"
+        assert "revoked_at" in body, "Response should include revoked_at"
 
-        # Verify placeholder message
-        assert isinstance(body["message"], str), "message should be a string"
-        assert "Revoke share endpoint" in body["message"], "Should contain placeholder text"
-        assert "to be implemented" in body["message"], "Should indicate implementation pending"
+        # Validate response values
+        assert body["message"] == "Share revoked successfully"
+        assert isinstance(body["revoked_at"], int), "revoked_at should be an integer"

--- a/lambda/tests/unit/routes/test_share_routes.py
+++ b/lambda/tests/unit/routes/test_share_routes.py
@@ -87,30 +87,38 @@ class TestGetShareRoute:
         self, mock_service_provider, dynamodb_stubber, items_table_name, shares_table_name
     ):
         """Test get share route handler returns expected response."""
-        share_id = "test-share-123"
+        share_id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
         item_id = "test-item-789"
         vault_id = "test-vault-456"
         user_id = "test-user-123"
         s3_key = f"vaults/{vault_id}/files/{item_id}/test"
         now = int(time.time())
 
-        # Stub 1: get_item on shares table (rate limit check)
+        # Stub 1: atomic per-IP rate limit increment
         dynamodb_stubber.add_response(
-            "get_item",
-            {},  # No rate limit entry found
-            expected_params={
+            "update_item",
+            {"Attributes": {"attempt_count": {"N": "1"}}},
+            {
                 "TableName": shares_table_name,
-                "Key": {"PK": f"SHARE#{share_id}", "SK": "RATE#1.2.3.4"},
+                "Key": ANY,
+                "UpdateExpression": ANY,
+                "ExpressionAttributeValues": ANY,
+                "ExpressionAttributeNames": ANY,
+                "ReturnValues": "ALL_NEW",
             },
         )
 
-        # Stub 2: put_item on shares table (create rate limit entry)
+        # Stub 2: atomic global rate limit increment
         dynamodb_stubber.add_response(
-            "put_item",
-            {},
+            "update_item",
+            {"Attributes": {"attempt_count": {"N": "1"}}},
             {
                 "TableName": shares_table_name,
-                "Item": ANY,
+                "Key": ANY,
+                "UpdateExpression": ANY,
+                "ExpressionAttributeValues": ANY,
+                "ExpressionAttributeNames": ANY,
+                "ReturnValues": "ALL_NEW",
             },
         )
 
@@ -212,7 +220,7 @@ class TestRevokeShareRoute:
         self, mock_service_provider, dynamodb_stubber, shares_table_name
     ):
         """Test revoke share route handler returns expected response."""
-        share_id = "test-share-123"
+        share_id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
         user_id = "test-user-123"
         item_id = "test-item-789"
         vault_id = "test-vault-456"

--- a/lambda/tests/unit/services/test_share_service.py
+++ b/lambda/tests/unit/services/test_share_service.py
@@ -9,14 +9,12 @@ Schema: PK: SHARE#{shareId}, SK: METADATA (share metadata)
 """
 
 import time
-from unittest.mock import patch
 
 import pytest
 from aws_lambda_powertools.event_handler.exceptions import NotFoundError
 from botocore.stub import ANY
 
 from src.api.services.share_service import (
-    RateLimitExceededError,
     ShareExpiredError,
     ShareRevokedError,
 )
@@ -98,9 +96,7 @@ class TestCreateShare:
     def test_create_share_item_not_found(self, share_service, dynamodb_stubber):
         """Test creating a share when item doesn't exist."""
         # Stub get_item returning empty (item not found)
-        dynamodb_stubber.add_response(
-            "get_item", {}, {"TableName": "test-items-table", "Key": ANY}
-        )
+        dynamodb_stubber.add_response("get_item", {}, {"TableName": "test-items-table", "Key": ANY})
 
         request = CreateShareRequest(item_id="nonexistent-item")
 
@@ -135,7 +131,9 @@ class TestCreateShare:
 class TestGetShare:
     """Tests for get_share method."""
 
-    def test_get_share_success(self, share_service, dynamodb_stubber, s3_stubber, files_bucket_name):
+    def test_get_share_success(
+        self, share_service, dynamodb_stubber, s3_stubber, files_bucket_name
+    ):
         """Test successfully accessing a share."""
         share_id = "share-123"
         item_id = "item-456"

--- a/lambda/tests/unit/services/test_share_service.py
+++ b/lambda/tests/unit/services/test_share_service.py
@@ -1,0 +1,389 @@
+"""
+Unit tests for ShareService.
+
+Tests the share service layer for creating shares, accessing shared items,
+revoking shares, and rate limiting.
+
+Schema: PK: SHARE#{shareId}, SK: METADATA (share metadata)
+        PK: SHARE#{shareId}, SK: RATE#{ipAddress} (rate limit)
+"""
+
+import time
+from unittest.mock import patch
+
+import pytest
+from aws_lambda_powertools.event_handler.exceptions import NotFoundError
+from botocore.stub import ANY
+
+from src.api.services.share_service import (
+    RateLimitExceededError,
+    ShareExpiredError,
+    ShareRevokedError,
+)
+from src.shared.models import CreateShareRequest
+
+
+class TestCreateShare:
+    """Tests for create_share method."""
+
+    def test_create_share_success(self, share_service, dynamodb_stubber):
+        """Test creating a share for an owned item."""
+        item_id = "item-123"
+        user_id = "user-123"
+
+        # Stub get_item for items table (verify ownership)
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"ITEM#{item_id}"},
+                    "SK": {"S": "METADATA"},
+                    "item_id": {"S": item_id},
+                    "user_id": {"S": user_id},
+                    "vault_id": {"S": "vault-123"},
+                    "item_type": {"S": "MEDIA"},
+                    "s3_key": {"S": f"vaults/vault-123/files/{item_id}/test"},
+                    "encrypted_metadata": {"B": b"encrypted-metadata"},
+                }
+            },
+            {"TableName": "test-items-table", "Key": {"PK": f"ITEM#{item_id}"}},
+        )
+
+        # Stub put_item for shares table
+        dynamodb_stubber.add_response(
+            "put_item", {}, {"TableName": "test-shares-table", "Item": ANY}
+        )
+
+        request = CreateShareRequest(item_id=item_id)
+        response = share_service.create_share(user_id, request)
+
+        assert response.share_id is not None
+        assert len(response.share_id) > 0
+        assert response.created_at > 0
+        assert response.expires_at is None
+
+    def test_create_share_with_expiration(self, share_service, dynamodb_stubber):
+        """Test creating a share with an expiration timestamp."""
+        item_id = "item-123"
+        user_id = "user-123"
+        expires_at = int(time.time()) + 86400  # 24 hours from now
+
+        # Stub get_item for items table
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"ITEM#{item_id}"},
+                    "SK": {"S": "METADATA"},
+                    "item_id": {"S": item_id},
+                    "user_id": {"S": user_id},
+                    "vault_id": {"S": "vault-123"},
+                    "item_type": {"S": "MEDIA"},
+                }
+            },
+            {"TableName": "test-items-table", "Key": {"PK": f"ITEM#{item_id}"}},
+        )
+
+        # Stub put_item for shares table
+        dynamodb_stubber.add_response(
+            "put_item", {}, {"TableName": "test-shares-table", "Item": ANY}
+        )
+
+        request = CreateShareRequest(item_id=item_id, expires_at=expires_at)
+        response = share_service.create_share(user_id, request)
+
+        assert response.share_id is not None
+        assert response.expires_at == expires_at
+
+    def test_create_share_item_not_found(self, share_service, dynamodb_stubber):
+        """Test creating a share when item doesn't exist."""
+        # Stub get_item returning empty (item not found)
+        dynamodb_stubber.add_response(
+            "get_item", {}, {"TableName": "test-items-table", "Key": ANY}
+        )
+
+        request = CreateShareRequest(item_id="nonexistent-item")
+
+        with pytest.raises(NotFoundError, match="Item not found"):
+            share_service.create_share("user-123", request)
+
+    def test_create_share_wrong_owner(self, share_service, dynamodb_stubber):
+        """Test creating a share for an item owned by a different user."""
+        item_id = "item-123"
+
+        # Stub get_item returning item owned by different user
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"ITEM#{item_id}"},
+                    "SK": {"S": "METADATA"},
+                    "item_id": {"S": item_id},
+                    "user_id": {"S": "other-user"},
+                    "vault_id": {"S": "vault-123"},
+                }
+            },
+            {"TableName": "test-items-table", "Key": {"PK": f"ITEM#{item_id}"}},
+        )
+
+        request = CreateShareRequest(item_id=item_id)
+
+        with pytest.raises(NotFoundError, match="Item not found"):
+            share_service.create_share("user-123", request)
+
+
+class TestGetShare:
+    """Tests for get_share method."""
+
+    def test_get_share_success(self, share_service, dynamodb_stubber, s3_stubber, files_bucket_name):
+        """Test successfully accessing a share."""
+        share_id = "share-123"
+        item_id = "item-456"
+        client_ip = "192.168.1.1"
+        s3_key = "vaults/vault-123/files/item-456/test"
+
+        # Stub rate limit check (get_item returns empty = no prior attempts)
+        dynamodb_stubber.add_response(
+            "get_item",
+            {},
+            {
+                "TableName": "test-shares-table",
+                "Key": {"PK": f"SHARE#{share_id}", "SK": f"RATE#{client_ip}"},
+            },
+        )
+
+        # Stub rate limit put_item (create new rate entry)
+        dynamodb_stubber.add_response(
+            "put_item", {}, {"TableName": "test-shares-table", "Item": ANY}
+        )
+
+        # Stub get share metadata
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"SHARE#{share_id}"},
+                    "SK": {"S": "METADATA"},
+                    "share_id": {"S": share_id},
+                    "item_id": {"S": item_id},
+                    "user_id": {"S": "user-123"},
+                    "vault_id": {"S": "vault-123"},
+                    "is_revoked": {"BOOL": False},
+                    "access_count": {"N": "0"},
+                    "created_at": {"N": str(int(time.time()))},
+                }
+            },
+            {
+                "TableName": "test-shares-table",
+                "Key": {"PK": f"SHARE#{share_id}", "SK": "METADATA"},
+            },
+        )
+
+        # Stub get item (for s3_key)
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"ITEM#{item_id}"},
+                    "SK": {"S": "METADATA"},
+                    "item_id": {"S": item_id},
+                    "user_id": {"S": "user-123"},
+                    "vault_id": {"S": "vault-123"},
+                    "s3_key": {"S": s3_key},
+                    "item_type": {"S": "MEDIA"},
+                }
+            },
+            {"TableName": "test-items-table", "Key": {"PK": f"ITEM#{item_id}"}},
+        )
+
+        # Stub update access count
+        dynamodb_stubber.add_response(
+            "update_item",
+            {"Attributes": {}},
+            {
+                "TableName": "test-shares-table",
+                "Key": {"PK": f"SHARE#{share_id}", "SK": "METADATA"},
+                "UpdateExpression": ANY,
+                "ExpressionAttributeValues": ANY,
+                "ReturnValues": "ALL_NEW",
+            },
+        )
+
+        response = share_service.get_share(share_id, client_ip)
+
+        assert response.share_id == share_id
+        assert response.item_id == item_id
+        assert response.download_url is not None
+        assert response.url_expires_at > 0
+        assert response.expires_at is None
+
+    def test_get_share_revoked(self, share_service, dynamodb_stubber):
+        """Test accessing a revoked share raises ShareRevokedError."""
+        share_id = "share-123"
+        client_ip = "192.168.1.1"
+
+        # Stub rate limit check (no prior attempts)
+        dynamodb_stubber.add_response(
+            "get_item",
+            {},
+            {
+                "TableName": "test-shares-table",
+                "Key": {"PK": f"SHARE#{share_id}", "SK": f"RATE#{client_ip}"},
+            },
+        )
+
+        # Stub rate limit put_item
+        dynamodb_stubber.add_response(
+            "put_item", {}, {"TableName": "test-shares-table", "Item": ANY}
+        )
+
+        # Stub get share metadata (revoked)
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"SHARE#{share_id}"},
+                    "SK": {"S": "METADATA"},
+                    "share_id": {"S": share_id},
+                    "item_id": {"S": "item-456"},
+                    "user_id": {"S": "user-123"},
+                    "vault_id": {"S": "vault-123"},
+                    "is_revoked": {"BOOL": True},
+                    "access_count": {"N": "5"},
+                    "created_at": {"N": str(int(time.time()))},
+                }
+            },
+            {
+                "TableName": "test-shares-table",
+                "Key": {"PK": f"SHARE#{share_id}", "SK": "METADATA"},
+            },
+        )
+
+        with pytest.raises(ShareRevokedError):
+            share_service.get_share(share_id, client_ip)
+
+    def test_get_share_expired(self, share_service, dynamodb_stubber):
+        """Test accessing an expired share raises ShareExpiredError."""
+        share_id = "share-123"
+        client_ip = "192.168.1.1"
+        expired_time = int(time.time()) - 3600  # 1 hour ago
+
+        # Stub rate limit check (no prior attempts)
+        dynamodb_stubber.add_response(
+            "get_item",
+            {},
+            {
+                "TableName": "test-shares-table",
+                "Key": {"PK": f"SHARE#{share_id}", "SK": f"RATE#{client_ip}"},
+            },
+        )
+
+        # Stub rate limit put_item
+        dynamodb_stubber.add_response(
+            "put_item", {}, {"TableName": "test-shares-table", "Item": ANY}
+        )
+
+        # Stub get share metadata (expired)
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"SHARE#{share_id}"},
+                    "SK": {"S": "METADATA"},
+                    "share_id": {"S": share_id},
+                    "item_id": {"S": "item-456"},
+                    "user_id": {"S": "user-123"},
+                    "vault_id": {"S": "vault-123"},
+                    "is_revoked": {"BOOL": False},
+                    "expires_at": {"N": str(expired_time)},
+                    "access_count": {"N": "3"},
+                    "created_at": {"N": str(expired_time - 86400)},
+                }
+            },
+            {
+                "TableName": "test-shares-table",
+                "Key": {"PK": f"SHARE#{share_id}", "SK": "METADATA"},
+            },
+        )
+
+        with pytest.raises(ShareExpiredError):
+            share_service.get_share(share_id, client_ip)
+
+
+class TestRevokeShare:
+    """Tests for revoke_share method."""
+
+    def test_revoke_share_success(self, share_service, dynamodb_stubber):
+        """Test successfully revoking a share."""
+        share_id = "share-123"
+        user_id = "user-123"
+
+        # Stub get share metadata
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"SHARE#{share_id}"},
+                    "SK": {"S": "METADATA"},
+                    "share_id": {"S": share_id},
+                    "item_id": {"S": "item-456"},
+                    "user_id": {"S": user_id},
+                    "vault_id": {"S": "vault-123"},
+                    "is_revoked": {"BOOL": False},
+                    "access_count": {"N": "2"},
+                    "created_at": {"N": str(int(time.time()))},
+                }
+            },
+            {
+                "TableName": "test-shares-table",
+                "Key": {"PK": f"SHARE#{share_id}", "SK": "METADATA"},
+            },
+        )
+
+        # Stub update_item (set is_revoked and ttl)
+        dynamodb_stubber.add_response(
+            "update_item",
+            {"Attributes": {}},
+            {
+                "TableName": "test-shares-table",
+                "Key": {"PK": f"SHARE#{share_id}", "SK": "METADATA"},
+                "UpdateExpression": ANY,
+                "ExpressionAttributeValues": ANY,
+                "ExpressionAttributeNames": ANY,
+                "ReturnValues": "ALL_NEW",
+            },
+        )
+
+        response = share_service.revoke_share(user_id, share_id)
+
+        assert response.message == "Share revoked successfully"
+        assert response.revoked_at > 0
+
+    def test_revoke_share_wrong_owner(self, share_service, dynamodb_stubber):
+        """Test revoking a share owned by a different user."""
+        share_id = "share-123"
+
+        # Stub get share metadata (owned by different user)
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"SHARE#{share_id}"},
+                    "SK": {"S": "METADATA"},
+                    "share_id": {"S": share_id},
+                    "item_id": {"S": "item-456"},
+                    "user_id": {"S": "other-user"},
+                    "vault_id": {"S": "vault-123"},
+                    "is_revoked": {"BOOL": False},
+                    "access_count": {"N": "0"},
+                    "created_at": {"N": str(int(time.time()))},
+                }
+            },
+            {
+                "TableName": "test-shares-table",
+                "Key": {"PK": f"SHARE#{share_id}", "SK": "METADATA"},
+            },
+        )
+
+        with pytest.raises(NotFoundError, match="Share not found"):
+            share_service.revoke_share("user-123", share_id)

--- a/lambda/tests/unit/services/test_share_service.py
+++ b/lambda/tests/unit/services/test_share_service.py
@@ -140,19 +140,32 @@ class TestGetShare:
         client_ip = "192.168.1.1"
         s3_key = "vaults/vault-123/files/item-456/test"
 
-        # Stub rate limit check (get_item returns empty = no prior attempts)
+        # Stub atomic per-IP rate limit increment
         dynamodb_stubber.add_response(
-            "get_item",
-            {},
+            "update_item",
+            {"Attributes": {"attempt_count": {"N": "1"}}},
             {
                 "TableName": "test-shares-table",
-                "Key": {"PK": f"SHARE#{share_id}", "SK": f"RATE#{client_ip}"},
+                "Key": ANY,
+                "UpdateExpression": ANY,
+                "ExpressionAttributeValues": ANY,
+                "ExpressionAttributeNames": ANY,
+                "ReturnValues": "ALL_NEW",
             },
         )
 
-        # Stub rate limit put_item (create new rate entry)
+        # Stub atomic global rate limit increment
         dynamodb_stubber.add_response(
-            "put_item", {}, {"TableName": "test-shares-table", "Item": ANY}
+            "update_item",
+            {"Attributes": {"attempt_count": {"N": "1"}}},
+            {
+                "TableName": "test-shares-table",
+                "Key": ANY,
+                "UpdateExpression": ANY,
+                "ExpressionAttributeValues": ANY,
+                "ExpressionAttributeNames": ANY,
+                "ReturnValues": "ALL_NEW",
+            },
         )
 
         # Stub get share metadata
@@ -220,19 +233,32 @@ class TestGetShare:
         share_id = "share-123"
         client_ip = "192.168.1.1"
 
-        # Stub rate limit check (no prior attempts)
+        # Stub atomic per-IP rate limit increment
         dynamodb_stubber.add_response(
-            "get_item",
-            {},
+            "update_item",
+            {"Attributes": {"attempt_count": {"N": "1"}}},
             {
                 "TableName": "test-shares-table",
-                "Key": {"PK": f"SHARE#{share_id}", "SK": f"RATE#{client_ip}"},
+                "Key": ANY,
+                "UpdateExpression": ANY,
+                "ExpressionAttributeValues": ANY,
+                "ExpressionAttributeNames": ANY,
+                "ReturnValues": "ALL_NEW",
             },
         )
 
-        # Stub rate limit put_item
+        # Stub atomic global rate limit increment
         dynamodb_stubber.add_response(
-            "put_item", {}, {"TableName": "test-shares-table", "Item": ANY}
+            "update_item",
+            {"Attributes": {"attempt_count": {"N": "1"}}},
+            {
+                "TableName": "test-shares-table",
+                "Key": ANY,
+                "UpdateExpression": ANY,
+                "ExpressionAttributeValues": ANY,
+                "ExpressionAttributeNames": ANY,
+                "ReturnValues": "ALL_NEW",
+            },
         )
 
         # Stub get share metadata (revoked)
@@ -266,19 +292,32 @@ class TestGetShare:
         client_ip = "192.168.1.1"
         expired_time = int(time.time()) - 3600  # 1 hour ago
 
-        # Stub rate limit check (no prior attempts)
+        # Stub atomic per-IP rate limit increment
         dynamodb_stubber.add_response(
-            "get_item",
-            {},
+            "update_item",
+            {"Attributes": {"attempt_count": {"N": "1"}}},
             {
                 "TableName": "test-shares-table",
-                "Key": {"PK": f"SHARE#{share_id}", "SK": f"RATE#{client_ip}"},
+                "Key": ANY,
+                "UpdateExpression": ANY,
+                "ExpressionAttributeValues": ANY,
+                "ExpressionAttributeNames": ANY,
+                "ReturnValues": "ALL_NEW",
             },
         )
 
-        # Stub rate limit put_item
+        # Stub atomic global rate limit increment
         dynamodb_stubber.add_response(
-            "put_item", {}, {"TableName": "test-shares-table", "Item": ANY}
+            "update_item",
+            {"Attributes": {"attempt_count": {"N": "1"}}},
+            {
+                "TableName": "test-shares-table",
+                "Key": ANY,
+                "UpdateExpression": ANY,
+                "ExpressionAttributeValues": ANY,
+                "ExpressionAttributeNames": ANY,
+                "ReturnValues": "ALL_NEW",
+            },
         )
 
         # Stub get share metadata (expired)

--- a/lambda/tests/unit/shared/test_models.py
+++ b/lambda/tests/unit/shared/test_models.py
@@ -205,26 +205,17 @@ class TestCreateShareRequest:
 
     def test_valid_request_minimal(self):
         """Should create valid request with minimal fields."""
-        request = CreateShareRequest(file_id="file-123", vault_id="vault-456")
+        request = CreateShareRequest(item_id="item-123")
 
-        assert request.file_id == "file-123"
-        assert request.vault_id == "vault-456"
+        assert request.item_id == "item-123"
         assert request.expires_at is None
-        assert request.is_password_protected is False
 
-    def test_with_expiration(self, now):
-        """Should accept expiration timestamp."""
-        request = CreateShareRequest(file_id="file-123", vault_id="vault-456", expires_at=now)
+    def test_with_expiration(self):
+        """Should accept expiration timestamp as Unix epoch."""
+        expires_at = 1738800000
+        request = CreateShareRequest(item_id="item-123", expires_at=expires_at)
 
-        assert request.expires_at == now
-
-    def test_with_password_protection(self):
-        """Should accept password protection flag."""
-        request = CreateShareRequest(
-            file_id="file-123", vault_id="vault-456", is_password_protected=True
-        )
-
-        assert request.is_password_protected is True
+        assert request.expires_at == expires_at
 
 
 class TestDynamoDBFileItem:
@@ -299,7 +290,7 @@ class TestDynamoDBShareItem:
             PK="SHARE#share-123",
             SK="METADATA",
             share_id="share-123",
-            file_id="file-456",
+            item_id="item-456",
             vault_id="vault-789",
             user_id="user-abc",
             created_at=1234567890,
@@ -307,11 +298,12 @@ class TestDynamoDBShareItem:
 
         assert item.PK == "SHARE#share-123"
         assert item.SK == "METADATA"
-        assert item.is_password_protected is False
+        assert item.item_id == "item-456"
         assert item.is_revoked is False
         assert item.access_count == 0
         assert item.expires_at is None
         assert item.last_accessed_at is None
+        assert item.ttl is None
 
     def test_with_all_fields(self):
         """Should accept all optional fields."""
@@ -319,22 +311,23 @@ class TestDynamoDBShareItem:
             PK="SHARE#share-123",
             SK="METADATA",
             share_id="share-123",
-            file_id="file-456",
+            item_id="item-456",
             vault_id="vault-789",
             user_id="user-abc",
             created_at=1234567890,
             expires_at=1234567900,
-            is_password_protected=True,
             is_revoked=True,
             access_count=5,
             last_accessed_at=1234567895,
+            ttl=1234654290,
         )
 
+        assert item.item_id == "item-456"
         assert item.expires_at == 1234567900
-        assert item.is_password_protected is True
         assert item.is_revoked is True
         assert item.access_count == 5
         assert item.last_accessed_at == 1234567895
+        assert item.ttl == 1234654290
 
 
 class TestDynamoDBRecoveryCodeItem:

--- a/packages/encryption/src/index.ts
+++ b/packages/encryption/src/index.ts
@@ -62,3 +62,14 @@ export {
   DekUnwrapError,
   type DekUnwrapErrorCode,
 } from './lib/envelope-encryption';
+
+// Export share encryption functions
+export {
+  deriveShareKeys,
+  computeShareHmac,
+  verifyShareHmac,
+  encodeShareBlob,
+  decodeShareBlob,
+  type ShareKeys,
+  type ShareBlob,
+} from './lib/share-encryption';

--- a/packages/encryption/src/lib/share-encryption.ts
+++ b/packages/encryption/src/lib/share-encryption.ts
@@ -1,0 +1,461 @@
+/**
+ * Share Encryption Module
+ *
+ * Implements password-protected file sharing for Cortex's zero-knowledge
+ * architecture. A share password is used to derive encryption and HMAC keys
+ * via Argon2id + HKDF. The resulting keys protect the shared file's DEK
+ * and authenticate share metadata.
+ *
+ * Key derivation chain:
+ *   share_password + salt(16) -> Argon2id(64MB, 3 iter, 4 par) -> master(32)
+ *   master -> HKDF-SHA256(salt: "cortex-salt-share-enc-v1",
+ *                          info: "cortex-share-key-v1") -> encryptionKey(32)
+ *   master -> HKDF-SHA256(salt: "cortex-salt-share-hmac-v1",
+ *                          info: "cortex-share-hmac-v1") -> hmacKey(32)
+ *
+ * Blob binary format:
+ *   [version(1)][salt(16)][wrappedDek(65)][hmac(32)] = 114 bytes -> ~152 chars base64url
+ */
+
+import { hkdf } from '@noble/hashes/hkdf';
+import { sha256 } from '@noble/hashes/sha2';
+import { hmac } from '@noble/hashes/hmac';
+
+// Dynamic import for argon2id to handle both browser and Node.js environments
+let loadArgon2idWasm: (() => Promise<(params: {
+  password: Uint8Array;
+  salt: Uint8Array;
+  parallelism: number;
+  passes: number;
+  memorySize: number;
+  tagLength: number;
+}) => Uint8Array>) | null = null;
+
+// Initialize the loader based on environment
+async function initArgon2idLoader() {
+  if (loadArgon2idWasm) return loadArgon2idWasm;
+
+  // Check if we're in Node.js environment
+  if (typeof process !== 'undefined' && process.versions && process.versions.node) {
+    try {
+      const fs = await import('fs');
+      const path = await import('path');
+      const { fileURLToPath } = await import('url');
+      const setupWasm = (await import('argon2id/lib/setup.js')).default;
+
+      let argon2idPath: string;
+
+      try {
+        const argon2idPackageUrl = import.meta.resolve('argon2id');
+        const argon2idPackagePath = fileURLToPath(argon2idPackageUrl);
+        argon2idPath = path.dirname(argon2idPackagePath);
+      } catch (resolveError) {
+        try {
+          const argon2idMainPath = require.resolve('argon2id');
+          argon2idPath = path.dirname(argon2idMainPath);
+        } catch (requireError) {
+          throw new Error(
+            'Failed to resolve argon2id package location. ' +
+            'Ensure argon2id is installed and accessible. ' +
+            `import.meta.resolve error: ${resolveError instanceof Error ? resolveError.message : 'unknown'}; ` +
+            `require.resolve error: ${requireError instanceof Error ? requireError.message : 'unknown'}`
+          );
+        }
+      }
+
+      const simdPath = path.join(argon2idPath, 'dist/simd.wasm');
+      const nonSimdPath = path.join(argon2idPath, 'dist/no-simd.wasm');
+
+      loadArgon2idWasm = () => setupWasm(
+        (importObject: WebAssembly.Imports) => WebAssembly.instantiate(fs.readFileSync(simdPath), importObject),
+        (importObject: WebAssembly.Imports) => WebAssembly.instantiate(fs.readFileSync(nonSimdPath), importObject)
+      );
+    } catch (error) {
+      throw new Error(`Failed to initialize Argon2id for Node.js: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  } else {
+    // Browser environment - use default loader
+    const defaultLoader = (await import('argon2id')).default;
+    loadArgon2idWasm = defaultLoader;
+  }
+
+  return loadArgon2idWasm;
+}
+
+/**
+ * Argon2id parameters for share key derivation
+ * Matches vault key derivation: 64MB memory, 3 iterations, 4 parallelism
+ */
+const ARGON2_PARAMS = {
+  memorySize: 65536, // 64MB in KB
+  passes: 3,
+  parallelism: 4,
+  tagLength: 32, // 256 bits output
+};
+
+/**
+ * Cached Argon2id WASM instance
+ */
+let argon2idInstance: ((params: {
+  password: Uint8Array;
+  salt: Uint8Array;
+  parallelism: number;
+  passes: number;
+  memorySize: number;
+  tagLength: number;
+}) => Uint8Array) | null = null;
+
+async function getArgon2id() {
+  if (!argon2idInstance) {
+    const loader = await initArgon2idLoader();
+    argon2idInstance = await loader();
+  }
+  return argon2idInstance;
+}
+
+// --- HKDF salts and contexts for share key derivation ---
+
+const HKDF_SHARE_SALTS = {
+  ENCRYPTION: new TextEncoder().encode('cortex-salt-share-enc-v1'),
+  HMAC: new TextEncoder().encode('cortex-salt-share-hmac-v1'),
+};
+
+const HKDF_SHARE_CONTEXTS = {
+  ENCRYPTION: 'cortex-share-key-v1',
+  HMAC: 'cortex-share-hmac-v1',
+};
+
+// --- Blob format constants ---
+
+const BLOB_VERSION_SIZE = 1;
+const BLOB_SALT_SIZE = 16;
+const BLOB_WRAPPED_DEK_SIZE = 65;
+const BLOB_HMAC_SIZE = 32;
+const BLOB_TOTAL_SIZE = BLOB_VERSION_SIZE + BLOB_SALT_SIZE + BLOB_WRAPPED_DEK_SIZE + BLOB_HMAC_SIZE; // 114
+
+// --- Interface for derived share keys ---
+
+export interface ShareKeys {
+  encryptionKey: Uint8Array;
+  hmacKey: Uint8Array;
+}
+
+// --- Interface for decoded share blob ---
+
+export interface ShareBlob {
+  version: number;
+  salt: Uint8Array;
+  wrappedDek: Uint8Array;
+  hmac: Uint8Array;
+}
+
+// --- base64url helpers (no padding, URL-safe) ---
+
+const BASE64URL_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+
+function bytesToBase64url(bytes: Uint8Array): string {
+  let result = '';
+  const len = bytes.length;
+
+  // Process full 3-byte groups
+  let i = 0;
+  for (; i + 2 < len; i += 3) {
+    const triplet = (bytes[i] << 16) | (bytes[i + 1] << 8) | bytes[i + 2];
+    result += BASE64URL_CHARS[(triplet >> 18) & 0x3f];
+    result += BASE64URL_CHARS[(triplet >> 12) & 0x3f];
+    result += BASE64URL_CHARS[(triplet >> 6) & 0x3f];
+    result += BASE64URL_CHARS[triplet & 0x3f];
+  }
+
+  // Handle remaining 1 or 2 bytes (no padding characters)
+  const remaining = len - i;
+  if (remaining === 1) {
+    const a = bytes[i];
+    result += BASE64URL_CHARS[(a >> 2) & 0x3f];
+    result += BASE64URL_CHARS[(a << 4) & 0x3f];
+  } else if (remaining === 2) {
+    const a = bytes[i];
+    const b = bytes[i + 1];
+    result += BASE64URL_CHARS[(a >> 2) & 0x3f];
+    result += BASE64URL_CHARS[((a << 4) | (b >> 4)) & 0x3f];
+    result += BASE64URL_CHARS[(b << 2) & 0x3f];
+  }
+
+  return result;
+}
+
+function base64urlToBytes(str: string): Uint8Array {
+  // Build reverse lookup
+  const lookup = new Uint8Array(128);
+  lookup.fill(0xff);
+  for (let i = 0; i < BASE64URL_CHARS.length; i++) {
+    lookup[BASE64URL_CHARS.charCodeAt(i)] = i;
+  }
+
+  const len = str.length;
+  // Calculate byte length: each group of 4 chars = 3 bytes,
+  // leftover 2 chars = 1 byte, leftover 3 chars = 2 bytes
+  const remainder = len % 4;
+  const fullGroups = Math.floor(len / 4);
+  const byteLen = fullGroups * 3 + (remainder === 2 ? 1 : remainder === 3 ? 2 : 0);
+  const bytes = new Uint8Array(byteLen);
+
+  let byteIdx = 0;
+  let strIdx = 0;
+
+  for (let g = 0; g < fullGroups; g++) {
+    const a = lookup[str.charCodeAt(strIdx++)];
+    const b = lookup[str.charCodeAt(strIdx++)];
+    const c = lookup[str.charCodeAt(strIdx++)];
+    const d = lookup[str.charCodeAt(strIdx++)];
+
+    if (a === 0xff || b === 0xff || c === 0xff || d === 0xff) {
+      throw new Error('Invalid base64url character');
+    }
+
+    const triplet = (a << 18) | (b << 12) | (c << 6) | d;
+    bytes[byteIdx++] = (triplet >> 16) & 0xff;
+    bytes[byteIdx++] = (triplet >> 8) & 0xff;
+    bytes[byteIdx++] = triplet & 0xff;
+  }
+
+  if (remainder === 2) {
+    const a = lookup[str.charCodeAt(strIdx++)];
+    const b = lookup[str.charCodeAt(strIdx++)];
+    if (a === 0xff || b === 0xff) {
+      throw new Error('Invalid base64url character');
+    }
+    bytes[byteIdx++] = ((a << 2) | (b >> 4)) & 0xff;
+  } else if (remainder === 3) {
+    const a = lookup[str.charCodeAt(strIdx++)];
+    const b = lookup[str.charCodeAt(strIdx++)];
+    const c = lookup[str.charCodeAt(strIdx++)];
+    if (a === 0xff || b === 0xff || c === 0xff) {
+      throw new Error('Invalid base64url character');
+    }
+    bytes[byteIdx++] = ((a << 2) | (b >> 4)) & 0xff;
+    bytes[byteIdx++] = ((b << 4) | (c >> 2)) & 0xff;
+  }
+
+  return bytes;
+}
+
+// --- Public API ---
+
+/**
+ * Derive share encryption and HMAC keys from a password and salt.
+ *
+ * Uses Argon2id (64MB, 3 iterations, 4 parallelism) to derive a 32-byte
+ * master key, then HKDF-SHA256 to derive separate encryption and HMAC keys.
+ * The master key is zeroed after child keys are derived.
+ *
+ * @param password - The share password
+ * @param salt - Random salt (at least 16 bytes)
+ * @returns Promise<ShareKeys> containing encryptionKey and hmacKey (32 bytes each)
+ */
+export async function deriveShareKeys(
+  password: string,
+  salt: Uint8Array
+): Promise<ShareKeys> {
+  if (!password || password.length === 0) {
+    throw new Error('Password cannot be empty');
+  }
+
+  if (!salt || salt.length < 16) {
+    throw new Error('Salt must be at least 16 bytes');
+  }
+
+  const keyLength = 32;
+
+  try {
+    const argon2id = await getArgon2id();
+
+    const passwordBytes = new TextEncoder().encode(password);
+
+    const shareMasterKey = argon2id({
+      password: passwordBytes,
+      salt,
+      ...ARGON2_PARAMS,
+    });
+
+    try {
+      const encryptionKey = hkdf(
+        sha256,
+        shareMasterKey,
+        HKDF_SHARE_SALTS.ENCRYPTION,
+        new TextEncoder().encode(HKDF_SHARE_CONTEXTS.ENCRYPTION),
+        keyLength
+      );
+
+      const hmacKey = hkdf(
+        sha256,
+        shareMasterKey,
+        HKDF_SHARE_SALTS.HMAC,
+        new TextEncoder().encode(HKDF_SHARE_CONTEXTS.HMAC),
+        keyLength
+      );
+
+      return { encryptionKey, hmacKey };
+    } finally {
+      // Zero the master key after deriving child keys
+      shareMasterKey.fill(0);
+    }
+  } catch (error) {
+    if (error instanceof Error && (
+      error.message === 'Password cannot be empty' ||
+      error.message === 'Salt must be at least 16 bytes'
+    )) {
+      throw error;
+    }
+    throw new Error(
+      `Failed to derive share keys: ${error instanceof Error ? error.message : 'Unknown error'}`
+    );
+  }
+}
+
+/**
+ * Compute a 32-byte HMAC-SHA256 over a share ID and optional expiry timestamp.
+ *
+ * The message is constructed as: shareId (or shareId + ":" + expiresAt if expiry provided).
+ *
+ * @param hmacKey - The 32-byte HMAC key (from deriveShareKeys)
+ * @param shareId - The share identifier
+ * @param expiresAt - Optional expiry timestamp (Unix seconds)
+ * @returns 32-byte HMAC
+ */
+export function computeShareHmac(
+  hmacKey: Uint8Array,
+  shareId: string,
+  expiresAt?: number
+): Uint8Array {
+  if (!hmacKey || hmacKey.length !== 32) {
+    throw new Error('HMAC key must be 32 bytes');
+  }
+
+  if (!shareId || shareId.length === 0) {
+    throw new Error('shareId cannot be empty');
+  }
+
+  let message = shareId;
+  if (expiresAt !== undefined && expiresAt !== null) {
+    message = `${shareId}:${expiresAt}`;
+  }
+
+  const messageBytes = new TextEncoder().encode(message);
+  return hmac(sha256, hmacKey, messageBytes);
+}
+
+/**
+ * Verify an HMAC using constant-time comparison (XOR loop).
+ *
+ * @param hmacKey - The 32-byte HMAC key
+ * @param shareId - The share identifier
+ * @param expiresAt - Optional expiry timestamp (Unix seconds)
+ * @param expectedHmac - The expected 32-byte HMAC to verify against
+ * @returns true if the HMAC matches, false otherwise
+ */
+export function verifyShareHmac(
+  hmacKey: Uint8Array,
+  shareId: string,
+  expiresAt: number | undefined,
+  expectedHmac: Uint8Array
+): boolean {
+  // Length check before computing (no timing leak since length is not secret)
+  if (!expectedHmac || expectedHmac.length !== 32) {
+    return false;
+  }
+
+  const computedHmac = computeShareHmac(hmacKey, shareId, expiresAt);
+
+  // Constant-time comparison with XOR loop
+  if (computedHmac.length !== expectedHmac.length) {
+    return false;
+  }
+
+  let diff = 0;
+  for (let i = 0; i < computedHmac.length; i++) {
+    diff |= computedHmac[i] ^ expectedHmac[i];
+  }
+
+  return diff === 0;
+}
+
+/**
+ * Encode share blob components into a base64url string (no padding).
+ *
+ * Binary format: [version(1)][salt(16)][wrappedDek(65)][hmac(32)] = 114 bytes
+ *
+ * @param version - Version byte (e.g. 0x01)
+ * @param salt - The 16-byte salt used for key derivation
+ * @param wrappedDek - The 65-byte wrapped DEK
+ * @param hmacValue - The 32-byte HMAC
+ * @returns base64url encoded string (~152 chars)
+ */
+export function encodeShareBlob(
+  version: number,
+  salt: Uint8Array,
+  wrappedDek: Uint8Array,
+  hmacValue: Uint8Array
+): string {
+  if (salt.length !== BLOB_SALT_SIZE) {
+    throw new Error(`Salt must be ${BLOB_SALT_SIZE} bytes`);
+  }
+  if (wrappedDek.length !== BLOB_WRAPPED_DEK_SIZE) {
+    throw new Error(`Wrapped DEK must be ${BLOB_WRAPPED_DEK_SIZE} bytes`);
+  }
+  if (hmacValue.length !== BLOB_HMAC_SIZE) {
+    throw new Error(`HMAC must be ${BLOB_HMAC_SIZE} bytes`);
+  }
+
+  const buffer = new Uint8Array(BLOB_TOTAL_SIZE);
+  let offset = 0;
+
+  buffer[offset] = version & 0xff;
+  offset += BLOB_VERSION_SIZE;
+
+  buffer.set(salt, offset);
+  offset += BLOB_SALT_SIZE;
+
+  buffer.set(wrappedDek, offset);
+  offset += BLOB_WRAPPED_DEK_SIZE;
+
+  buffer.set(hmacValue, offset);
+
+  return bytesToBase64url(buffer);
+}
+
+/**
+ * Decode a base64url share blob string back to its components.
+ *
+ * @param blob - The base64url encoded share blob string
+ * @returns ShareBlob with version, salt, wrappedDek, and hmac
+ */
+export function decodeShareBlob(blob: string): ShareBlob {
+  let bytes: Uint8Array;
+  try {
+    bytes = base64urlToBytes(blob);
+  } catch {
+    throw new Error('Invalid share blob: failed to decode base64url');
+  }
+
+  if (bytes.length !== BLOB_TOTAL_SIZE) {
+    throw new Error(
+      `Invalid share blob: expected ${BLOB_TOTAL_SIZE} bytes, got ${bytes.length}`
+    );
+  }
+
+  let offset = 0;
+
+  const version = bytes[offset];
+  offset += BLOB_VERSION_SIZE;
+
+  const salt = bytes.slice(offset, offset + BLOB_SALT_SIZE);
+  offset += BLOB_SALT_SIZE;
+
+  const wrappedDek = bytes.slice(offset, offset + BLOB_WRAPPED_DEK_SIZE);
+  offset += BLOB_WRAPPED_DEK_SIZE;
+
+  const hmacBytes = bytes.slice(offset, offset + BLOB_HMAC_SIZE);
+
+  return { version, salt, wrappedDek, hmac: hmacBytes };
+}

--- a/packages/encryption/tests/property/test_share_encryption.test.ts
+++ b/packages/encryption/tests/property/test_share_encryption.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Property-Based Tests for Share Encryption Module
+ *
+ * These tests verify that share keys enable file access without vault password,
+ * wrong passwords fail, HMACs detect tampering, and blobs round-trip correctly.
+ */
+
+import fc from 'fast-check';
+import {
+  generateDek,
+  wrapDek,
+  unwrapDek,
+  encryptFileWithDek,
+  DekUnwrapError,
+} from '../../src/lib/envelope-encryption';
+import {
+  deriveShareKeys,
+  computeShareHmac,
+  verifyShareHmac,
+  encodeShareBlob,
+  decodeShareBlob,
+} from '../../src/lib/share-encryption';
+
+describe('Share Encryption Property Tests', () => {
+  /**
+   * Property 20: Share keys enable file access without vault password
+   *
+   * Validates the full share workflow:
+   * 1. Owner encrypts a file with their vault KEK
+   * 2. Owner derives share keys from a password and re-wraps the DEK
+   * 3. Recipient derives the same share keys from the same password
+   * 4. Recipient unwraps the DEK and decrypts the file content
+   * 5. Decrypted content matches the original
+   */
+  test('Property 20: Share keys enable file access without vault password', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.uint8Array({ minLength: 1, maxLength: 5000 }),   // file content
+        fc.uint8Array({ minLength: 32, maxLength: 32 }),     // vault KEK
+        fc.string({ minLength: 1, maxLength: 30 }),          // share password
+        async (content, vaultKek, sharePassword) => {
+          // OWNER: Encrypt file with vault KEK
+          const { encryptedContent, wrappedDek } = await encryptFileWithDek(content, vaultKek);
+
+          // OWNER: Derive share keys from password
+          const salt = crypto.getRandomValues(new Uint8Array(16));
+          const { encryptionKey: shareKey } = await deriveShareKeys(sharePassword, salt);
+
+          // OWNER: Re-wrap the DEK with share key instead of vault KEK
+          const dek = unwrapDek(wrappedDek, vaultKek);
+          const shareWrappedDek = await wrapDek(dek, shareKey);
+          dek.fill(0); // Zero the DEK after use
+
+          // RECIPIENT: Derive share keys from the same password and salt
+          const { encryptionKey: recipientKey } = await deriveShareKeys(sharePassword, salt);
+
+          // RECIPIENT: Unwrap DEK using share key
+          const recipientDek = unwrapDek(shareWrappedDek, recipientKey);
+
+          // RECIPIENT: Decrypt the file content directly with chacha20poly1305
+          const { chacha20poly1305 } = await import('@noble/ciphers/chacha');
+          const nonce = encryptedContent.slice(0, 12);
+          const ciphertext = encryptedContent.slice(12);
+          const cipher = chacha20poly1305(recipientDek, nonce);
+          const decrypted = cipher.decrypt(ciphertext);
+
+          recipientDek.fill(0); // Zero the DEK after use
+
+          // VERIFY: Decrypted content matches original
+          expect(decrypted).toEqual(content);
+        }
+      ),
+      { numRuns: 50 }
+    );
+  }, 600000); // 10 minute timeout for Argon2id
+
+  /**
+   * Property 20b: Wrong share password cannot unwrap DEK
+   *
+   * Validates that a different password produces a different key,
+   * causing DEK unwrapping to fail with DekUnwrapError.
+   */
+  test('Property 20b: Wrong share password cannot unwrap DEK', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string({ minLength: 1, maxLength: 30 }),          // correct password
+        fc.string({ minLength: 1, maxLength: 30 }),          // wrong password
+        async (correctPassword, wrongPassword) => {
+          // Skip if passwords happen to be equal
+          if (correctPassword === wrongPassword) {
+            return true;
+          }
+
+          // Create a share with the correct password
+          const salt = crypto.getRandomValues(new Uint8Array(16));
+          const { encryptionKey: shareKey } = await deriveShareKeys(correctPassword, salt);
+
+          const dek = await generateDek();
+          const shareWrappedDek = await wrapDek(dek, shareKey);
+          dek.fill(0);
+
+          // Try to unwrap with wrong password's key
+          const { encryptionKey: wrongKey } = await deriveShareKeys(wrongPassword, salt);
+
+          expect(() => unwrapDek(shareWrappedDek, wrongKey)).toThrow(DekUnwrapError);
+          return true;
+        }
+      ),
+      { numRuns: 50 }
+    );
+  }, 600000); // 10 minute timeout for Argon2id
+
+  /**
+   * Property 20c: HMAC detects metadata tampering
+   *
+   * Validates that verifyShareHmac returns true for the correct shareId
+   * and false when the shareId has been tampered with.
+   */
+  test('Property 20c: HMAC detects metadata tampering', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string({ minLength: 1, maxLength: 30 }),          // password
+        fc.string({ minLength: 1, maxLength: 50 }),          // correct shareId
+        fc.string({ minLength: 1, maxLength: 50 }),          // tampered shareId
+        fc.integer({ min: 1000000000, max: 2000000000 }),    // expiresAt
+        async (password, correctShareId, tamperedShareId, expiresAt) => {
+          // Skip if shareIds happen to be equal
+          if (correctShareId === tamperedShareId) {
+            return true;
+          }
+
+          const salt = crypto.getRandomValues(new Uint8Array(16));
+          const { hmacKey } = await deriveShareKeys(password, salt);
+
+          // Compute HMAC with correct shareId
+          const hmacValue = computeShareHmac(hmacKey, correctShareId, expiresAt);
+
+          // Verify with correct shareId should return true
+          expect(verifyShareHmac(hmacKey, correctShareId, expiresAt, hmacValue)).toBe(true);
+
+          // Verify with tampered shareId should return false
+          expect(verifyShareHmac(hmacKey, tamperedShareId, expiresAt, hmacValue)).toBe(false);
+
+          return true;
+        }
+      ),
+      { numRuns: 50 }
+    );
+  }, 600000); // 10 minute timeout for Argon2id
+
+  /**
+   * Property 20d: Share blob encode/decode round-trip
+   *
+   * Validates that encoding a share blob and decoding it produces
+   * the exact same component fields.
+   */
+  test('Property 20d: Share blob encode/decode round-trip', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.uint8Array({ minLength: 16, maxLength: 16 }),     // salt
+        fc.uint8Array({ minLength: 65, maxLength: 65 }),     // wrappedDek
+        fc.uint8Array({ minLength: 32, maxLength: 32 }),     // hmac
+        async (salt, wrappedDek, hmacValue) => {
+          const version = 0x01;
+
+          // Encode to base64url
+          const encoded = encodeShareBlob(version, salt, wrappedDek, hmacValue);
+
+          // Decode back
+          const decoded = decodeShareBlob(encoded);
+
+          // Verify all fields match
+          expect(decoded.version).toBe(version);
+          expect(decoded.salt).toEqual(salt);
+          expect(decoded.wrappedDek).toEqual(wrappedDek);
+          expect(decoded.hmac).toEqual(hmacValue);
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+});

--- a/packages/encryption/tests/unit/test_share_encryption.test.ts
+++ b/packages/encryption/tests/unit/test_share_encryption.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Unit tests for share encryption module
+ *
+ * Tests key derivation, HMAC computation/verification, and blob encode/decode
+ * for the password-protected file sharing system.
+ */
+
+import {
+  deriveShareKeys,
+  computeShareHmac,
+  verifyShareHmac,
+  encodeShareBlob,
+  decodeShareBlob,
+} from '../../src/lib/share-encryption';
+
+describe('Share Encryption Module', () => {
+  // Fixed test salt (16 bytes)
+  const testSalt = new Uint8Array(16);
+  for (let i = 0; i < 16; i++) {
+    testSalt[i] = i;
+  }
+
+  // Fixed test password
+  const testPassword = 'test-share-password-123';
+
+  describe('deriveShareKeys', () => {
+    it('should derive encryptionKey and hmacKey of 32 bytes each', async () => {
+      const keys = await deriveShareKeys(testPassword, testSalt);
+
+      expect(keys.encryptionKey).toBeInstanceOf(Uint8Array);
+      expect(keys.encryptionKey.length).toBe(32);
+      expect(keys.hmacKey).toBeInstanceOf(Uint8Array);
+      expect(keys.hmacKey.length).toBe(32);
+    });
+
+    it('should derive different encryptionKey and hmacKey', async () => {
+      const keys = await deriveShareKeys(testPassword, testSalt);
+
+      expect(keys.encryptionKey).not.toEqual(keys.hmacKey);
+    });
+
+    it('should be deterministic for the same password and salt', async () => {
+      const keys1 = await deriveShareKeys(testPassword, testSalt);
+      const keys2 = await deriveShareKeys(testPassword, testSalt);
+
+      expect(keys1.encryptionKey).toEqual(keys2.encryptionKey);
+      expect(keys1.hmacKey).toEqual(keys2.hmacKey);
+    });
+
+    it('should produce different keys for different passwords', async () => {
+      const keys1 = await deriveShareKeys('password-one', testSalt);
+      const keys2 = await deriveShareKeys('password-two', testSalt);
+
+      expect(keys1.encryptionKey).not.toEqual(keys2.encryptionKey);
+      expect(keys1.hmacKey).not.toEqual(keys2.hmacKey);
+    });
+
+    it('should produce different keys for different salts', async () => {
+      const salt2 = new Uint8Array(16);
+      salt2.fill(0xff);
+
+      const keys1 = await deriveShareKeys(testPassword, testSalt);
+      const keys2 = await deriveShareKeys(testPassword, salt2);
+
+      expect(keys1.encryptionKey).not.toEqual(keys2.encryptionKey);
+      expect(keys1.hmacKey).not.toEqual(keys2.hmacKey);
+    });
+
+    it('should throw error for empty password', async () => {
+      await expect(deriveShareKeys('', testSalt)).rejects.toThrow(
+        'Password cannot be empty'
+      );
+    });
+
+    it('should throw error for salt shorter than 16 bytes', async () => {
+      const shortSalt = new Uint8Array(8);
+      await expect(deriveShareKeys(testPassword, shortSalt)).rejects.toThrow(
+        'Salt must be at least 16 bytes'
+      );
+    });
+  });
+
+  describe('computeShareHmac', () => {
+    // Use a fixed 32-byte hmacKey for testing
+    const hmacKey = new Uint8Array(32);
+    for (let i = 0; i < 32; i++) {
+      hmacKey[i] = i + 100;
+    }
+
+    it('should produce a 32-byte HMAC', () => {
+      const result = computeShareHmac(hmacKey, 'share-id-123');
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result.length).toBe(32);
+    });
+
+    it('should be deterministic', () => {
+      const hmac1 = computeShareHmac(hmacKey, 'share-id-123');
+      const hmac2 = computeShareHmac(hmacKey, 'share-id-123');
+      expect(hmac1).toEqual(hmac2);
+    });
+
+    it('should produce different HMACs for different shareIds', () => {
+      const hmac1 = computeShareHmac(hmacKey, 'share-id-1');
+      const hmac2 = computeShareHmac(hmacKey, 'share-id-2');
+      expect(hmac1).not.toEqual(hmac2);
+    });
+
+    it('should produce different HMACs for different keys', () => {
+      const key2 = new Uint8Array(32);
+      key2.fill(0xff);
+
+      const hmac1 = computeShareHmac(hmacKey, 'share-id-123');
+      const hmac2 = computeShareHmac(key2, 'share-id-123');
+      expect(hmac1).not.toEqual(hmac2);
+    });
+
+    it('should include expiresAt in HMAC when provided', () => {
+      const expiresAt = 1700000000;
+      const hmacWithExpiry = computeShareHmac(hmacKey, 'share-id-123', expiresAt);
+      const hmacWithoutExpiry = computeShareHmac(hmacKey, 'share-id-123');
+      expect(hmacWithExpiry).not.toEqual(hmacWithoutExpiry);
+    });
+
+    it('should produce different HMACs for different expiresAt values', () => {
+      const hmac1 = computeShareHmac(hmacKey, 'share-id-123', 1700000000);
+      const hmac2 = computeShareHmac(hmacKey, 'share-id-123', 1700000001);
+      expect(hmac1).not.toEqual(hmac2);
+    });
+
+    it('should throw error for invalid hmacKey length', () => {
+      const badKey = new Uint8Array(16);
+      expect(() => computeShareHmac(badKey, 'share-id-123')).toThrow(
+        'HMAC key must be 32 bytes'
+      );
+    });
+
+    it('should throw error for empty shareId', () => {
+      expect(() => computeShareHmac(hmacKey, '')).toThrow(
+        'shareId cannot be empty'
+      );
+    });
+  });
+
+  describe('verifyShareHmac', () => {
+    const hmacKey = new Uint8Array(32);
+    for (let i = 0; i < 32; i++) {
+      hmacKey[i] = i + 100;
+    }
+
+    it('should return true for a valid HMAC without expiry', () => {
+      const mac = computeShareHmac(hmacKey, 'share-id-123');
+      const result = verifyShareHmac(hmacKey, 'share-id-123', undefined, mac);
+      expect(result).toBe(true);
+    });
+
+    it('should return true for a valid HMAC with expiry', () => {
+      const expiresAt = 1700000000;
+      const mac = computeShareHmac(hmacKey, 'share-id-123', expiresAt);
+      const result = verifyShareHmac(hmacKey, 'share-id-123', expiresAt, mac);
+      expect(result).toBe(true);
+    });
+
+    it('should return false for a tampered HMAC', () => {
+      const mac = computeShareHmac(hmacKey, 'share-id-123');
+      const tampered = new Uint8Array(mac);
+      tampered[0] ^= 0xff;
+      const result = verifyShareHmac(hmacKey, 'share-id-123', undefined, tampered);
+      expect(result).toBe(false);
+    });
+
+    it('should return false for wrong shareId', () => {
+      const mac = computeShareHmac(hmacKey, 'share-id-123');
+      const result = verifyShareHmac(hmacKey, 'share-id-wrong', undefined, mac);
+      expect(result).toBe(false);
+    });
+
+    it('should return false for wrong expiresAt', () => {
+      const mac = computeShareHmac(hmacKey, 'share-id-123', 1700000000);
+      const result = verifyShareHmac(hmacKey, 'share-id-123', 9999999999, mac);
+      expect(result).toBe(false);
+    });
+
+    it('should return false for wrong key', () => {
+      const mac = computeShareHmac(hmacKey, 'share-id-123');
+      const wrongKey = new Uint8Array(32);
+      wrongKey.fill(0xff);
+      const result = verifyShareHmac(wrongKey, 'share-id-123', undefined, mac);
+      expect(result).toBe(false);
+    });
+
+    it('should return false for HMAC of wrong length', () => {
+      const shortMac = new Uint8Array(16);
+      const result = verifyShareHmac(hmacKey, 'share-id-123', undefined, shortMac);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('encodeShareBlob and decodeShareBlob', () => {
+    const version = 0x01;
+    const salt = new Uint8Array(16);
+    for (let i = 0; i < 16; i++) {
+      salt[i] = i;
+    }
+    const wrappedDek = new Uint8Array(65);
+    for (let i = 0; i < 65; i++) {
+      wrappedDek[i] = i + 50;
+    }
+    const hmacValue = new Uint8Array(32);
+    for (let i = 0; i < 32; i++) {
+      hmacValue[i] = i + 200;
+    }
+
+    it('should produce a base64url string', () => {
+      const blob = encodeShareBlob(version, salt, wrappedDek, hmacValue);
+      expect(typeof blob).toBe('string');
+      // base64url: only [A-Za-z0-9_-], no padding
+      expect(blob).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+
+    it('should produce a string of approximately 152 characters', () => {
+      const blob = encodeShareBlob(version, salt, wrappedDek, hmacValue);
+      // 114 bytes -> ceil(114 * 4/3) = 152 base64url chars (no padding)
+      expect(blob.length).toBe(152);
+    });
+
+    it('should not contain padding characters', () => {
+      const blob = encodeShareBlob(version, salt, wrappedDek, hmacValue);
+      expect(blob).not.toContain('=');
+    });
+
+    it('should round-trip encode and decode correctly', () => {
+      const blob = encodeShareBlob(version, salt, wrappedDek, hmacValue);
+      const decoded = decodeShareBlob(blob);
+
+      expect(decoded.version).toBe(version);
+      expect(decoded.salt).toEqual(salt);
+      expect(decoded.wrappedDek).toEqual(wrappedDek);
+      expect(decoded.hmac).toEqual(hmacValue);
+    });
+
+    it('should preserve all byte values in round-trip', () => {
+      // Use bytes with full range of values
+      const fullRangeSalt = new Uint8Array(16);
+      for (let i = 0; i < 16; i++) fullRangeSalt[i] = i * 16;
+      const fullRangeWrappedDek = new Uint8Array(65);
+      for (let i = 0; i < 65; i++) fullRangeWrappedDek[i] = (i * 4) % 256;
+      const fullRangeHmac = new Uint8Array(32);
+      for (let i = 0; i < 32; i++) fullRangeHmac[i] = (255 - i * 8) & 0xff;
+
+      const blob = encodeShareBlob(0x01, fullRangeSalt, fullRangeWrappedDek, fullRangeHmac);
+      const decoded = decodeShareBlob(blob);
+
+      expect(decoded.version).toBe(0x01);
+      expect(decoded.salt).toEqual(fullRangeSalt);
+      expect(decoded.wrappedDek).toEqual(fullRangeWrappedDek);
+      expect(decoded.hmac).toEqual(fullRangeHmac);
+    });
+
+    it('should throw error for invalid salt length', () => {
+      const badSalt = new Uint8Array(8);
+      expect(() => encodeShareBlob(version, badSalt, wrappedDek, hmacValue)).toThrow(
+        'Salt must be 16 bytes'
+      );
+    });
+
+    it('should throw error for invalid wrappedDek length', () => {
+      const badDek = new Uint8Array(32);
+      expect(() => encodeShareBlob(version, salt, badDek, hmacValue)).toThrow(
+        'Wrapped DEK must be 65 bytes'
+      );
+    });
+
+    it('should throw error for invalid HMAC length', () => {
+      const badHmac = new Uint8Array(16);
+      expect(() => encodeShareBlob(version, salt, wrappedDek, badHmac)).toThrow(
+        'HMAC must be 32 bytes'
+      );
+    });
+
+    it('should throw error for invalid blob string (wrong length)', () => {
+      expect(() => decodeShareBlob('abc')).toThrow('Invalid share blob');
+    });
+
+    it('should throw error for invalid base64url characters', () => {
+      // Create a string of the right length with invalid characters
+      const badBlob = '!' + 'A'.repeat(151);
+      expect(() => decodeShareBlob(badBlob)).toThrow();
+    });
+
+    it('should correctly extract version byte from decoded blob', () => {
+      const blobV1 = encodeShareBlob(0x01, salt, wrappedDek, hmacValue);
+      const blobV2 = encodeShareBlob(0x02, salt, wrappedDek, hmacValue);
+
+      expect(decodeShareBlob(blobV1).version).toBe(0x01);
+      expect(decodeShareBlob(blobV2).version).toBe(0x02);
+    });
+  });
+
+  describe('integration: deriveShareKeys + computeShareHmac + verifyShareHmac', () => {
+    it('should derive keys and verify HMAC end-to-end', async () => {
+      const password = 'my-secure-share-password';
+      const salt = new Uint8Array(16);
+      crypto.getRandomValues(salt);
+
+      const keys = await deriveShareKeys(password, salt);
+      const shareId = 'share-abc-123';
+      const expiresAt = Math.floor(Date.now() / 1000) + 3600;
+
+      const mac = computeShareHmac(keys.hmacKey, shareId, expiresAt);
+      const isValid = verifyShareHmac(keys.hmacKey, shareId, expiresAt, mac);
+      expect(isValid).toBe(true);
+
+      // Wrong password should derive different keys -> verification fails
+      const wrongKeys = await deriveShareKeys('wrong-password', salt);
+      const isInvalid = verifyShareHmac(wrongKeys.hmacKey, shareId, expiresAt, mac);
+      expect(isInvalid).toBe(false);
+    });
+  });
+
+  describe('integration: full blob round-trip with derived keys', () => {
+    it('should encode/decode blob with real derived HMAC', async () => {
+      const password = 'blob-test-password';
+      const salt = new Uint8Array(16);
+      crypto.getRandomValues(salt);
+
+      const keys = await deriveShareKeys(password, salt);
+      const shareId = 'share-xyz-789';
+      const mac = computeShareHmac(keys.hmacKey, shareId);
+
+      // Simulate a wrapped DEK (65 bytes)
+      const wrappedDek = new Uint8Array(65);
+      crypto.getRandomValues(wrappedDek);
+
+      const blob = encodeShareBlob(0x01, salt, wrappedDek, mac);
+      const decoded = decodeShareBlob(blob);
+
+      expect(decoded.version).toBe(0x01);
+      expect(decoded.salt).toEqual(salt);
+      expect(decoded.wrappedDek).toEqual(wrappedDek);
+
+      // Verify the HMAC extracted from the blob
+      const isValid = verifyShareHmac(keys.hmacKey, shareId, undefined, decoded.hmac);
+      expect(isValid).toBe(true);
+    });
+  });
+});

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,4 +1,12 @@
+import { ShareAccess } from './components/ShareAccess';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+
 function App() {
+  if (window.location.pathname.startsWith('/s')) {
+    return <ShareAccess apiBaseUrl={API_BASE_URL} />;
+  }
+
   return (
     <div style={{ padding: '2rem' }}>
       <h1>Cortex</h1>

--- a/packages/web/src/components/ShareAccess.tsx
+++ b/packages/web/src/components/ShareAccess.tsx
@@ -1,0 +1,339 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import {
+  deriveShareKeys,
+  verifyShareHmac,
+  decodeShareBlob,
+  unwrapDek,
+  DekUnwrapError,
+} from '@cortex/encryption';
+import { chacha20poly1305 } from '@noble/ciphers/chacha.js';
+
+const NONCE_SIZE = 12;
+const MAX_FAILURES_BEFORE_BACKOFF = 3;
+const BASE_BACKOFF_MS = 1000;
+const MAX_BACKOFF_MS = 30000;
+
+interface ShareAccessProps {
+  apiBaseUrl: string;
+}
+
+interface ShareMetadata {
+  itemId: string;
+  wrappedDek: string; // base64
+  fileName: string;
+  contentType: string;
+  expiresAt: number | null;
+  downloadUrl: string;
+}
+
+type AccessState =
+  | { step: 'loading' }
+  | { step: 'error'; message: string }
+  | { step: 'password' }
+  | { step: 'decrypting' }
+  | { step: 'done'; fileName: string };
+
+export function ShareAccess({ apiBaseUrl }: ShareAccessProps) {
+  const [state, setState] = useState<AccessState>({ step: 'loading' });
+  const [password, setPassword] = useState('');
+  const [failureCount, setFailureCount] = useState(0);
+  const [backoffUntil, setBackoffUntil] = useState<number | null>(null);
+  const shareIdRef = useRef('');
+  const blobRef = useRef('');
+
+  // Extract shareId from pathname and blob from fragment on mount
+  useEffect(() => {
+    const pathname = window.location.pathname;
+    const match = pathname.match(/^\/s\/([^/]+)/);
+    if (!match) {
+      setState({
+        step: 'error',
+        message: 'Invalid share URL: could not extract share ID.',
+      });
+      return;
+    }
+
+    const shareId = match[1];
+    const fragment = window.location.hash.slice(1); // remove leading #
+    if (!fragment) {
+      setState({
+        step: 'error',
+        message:
+          'Invalid share URL: missing key material in URL fragment. Was the URL truncated or processed by a URL shortener?',
+      });
+      return;
+    }
+
+    shareIdRef.current = shareId;
+    blobRef.current = fragment;
+    setState({ step: 'password' });
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+
+      if (!password) return;
+
+      // Client-side rate limiting
+      if (backoffUntil && Date.now() < backoffUntil) {
+        const remainingSec = Math.ceil((backoffUntil - Date.now()) / 1000);
+        setState({
+          step: 'error',
+          message: `Too many failed attempts. Please wait ${remainingSec} seconds.`,
+        });
+        return;
+      }
+
+      setState({ step: 'decrypting' });
+
+      const shareId = shareIdRef.current;
+      const blobString = blobRef.current;
+
+      try {
+        // 1. Decode the blob from the URL fragment
+        const blob = decodeShareBlob(blobString);
+
+        // 2. Fetch share metadata from API
+        const metaResponse = await fetch(
+          `${apiBaseUrl}/v1/shares/${encodeURIComponent(shareId)}`
+        );
+
+        if (metaResponse.status === 410) {
+          setState({
+            step: 'error',
+            message: 'This share link has expired or been revoked.',
+          });
+          return;
+        }
+
+        if (metaResponse.status === 429) {
+          setState({
+            step: 'error',
+            message: 'Too many requests. Please try again later.',
+          });
+          return;
+        }
+
+        if (!metaResponse.ok) {
+          throw new Error(
+            `Failed to fetch share metadata: ${metaResponse.status}`
+          );
+        }
+
+        const metadata: ShareMetadata = await metaResponse.json();
+
+        // 3. Derive share keys from password + salt (from blob)
+        const shareKeys = await deriveShareKeys(password, blob.salt);
+
+        // 4. Verify HMAC
+        const hmacValid = verifyShareHmac(
+          shareKeys.hmacKey,
+          shareId,
+          metadata.expiresAt ?? undefined,
+          blob.hmac
+        );
+
+        if (!hmacValid) {
+          handleFailure('Incorrect password or tampered share link.');
+          shareKeys.encryptionKey.fill(0);
+          shareKeys.hmacKey.fill(0);
+          return;
+        }
+
+        // 5. Unwrap the DEK using the share encryption key
+        const shareWrappedDek = base64ToUint8(metadata.wrappedDek);
+        let dek: Uint8Array;
+        try {
+          dek = unwrapDek(shareWrappedDek, shareKeys.encryptionKey);
+        } catch (err) {
+          shareKeys.encryptionKey.fill(0);
+          shareKeys.hmacKey.fill(0);
+          if (err instanceof DekUnwrapError) {
+            handleFailure('Incorrect password or corrupted share data.');
+            return;
+          }
+          throw err;
+        }
+
+        // Zero share keys
+        shareKeys.encryptionKey.fill(0);
+        shareKeys.hmacKey.fill(0);
+
+        // 6. Download encrypted file
+        const fileResponse = await fetch(metadata.downloadUrl);
+        if (!fileResponse.ok) {
+          dek.fill(0);
+          throw new Error(
+            `Failed to download encrypted file: ${fileResponse.status}`
+          );
+        }
+        const encryptedContent = new Uint8Array(
+          await fileResponse.arrayBuffer()
+        );
+
+        // 7. Decrypt with chacha20poly1305
+        //    Format: [nonce(12)][ciphertext + authTag]
+        if (encryptedContent.length < NONCE_SIZE + 16) {
+          dek.fill(0);
+          throw new Error('Encrypted file is too small to be valid.');
+        }
+
+        const nonce = encryptedContent.slice(0, NONCE_SIZE);
+        const ciphertext = encryptedContent.slice(NONCE_SIZE);
+
+        let plaintext: Uint8Array;
+        try {
+          const cipher = chacha20poly1305(dek, nonce);
+          plaintext = cipher.decrypt(ciphertext);
+        } catch {
+          dek.fill(0);
+          handleFailure('Decryption failed. The file may be corrupted.');
+          return;
+        } finally {
+          dek.fill(0);
+        }
+
+        // 8. Trigger browser download
+        const downloadBlob = new Blob([new Uint8Array(plaintext) as BlobPart], {
+          type: metadata.contentType || 'application/octet-stream',
+        });
+        const url = URL.createObjectURL(downloadBlob);
+        const anchor = document.createElement('a');
+        anchor.href = url;
+        anchor.download = metadata.fileName || 'download';
+        document.body.appendChild(anchor);
+        anchor.click();
+        document.body.removeChild(anchor);
+        URL.revokeObjectURL(url);
+
+        // Reset failure count on success
+        setFailureCount(0);
+        setBackoffUntil(null);
+
+        setState({ step: 'done', fileName: metadata.fileName || 'download' });
+      } catch (err) {
+        if (
+          (state as { step: string }).step !== 'error'
+        ) {
+          setState({
+            step: 'error',
+            message:
+              err instanceof Error ? err.message : 'An unexpected error occurred.',
+          });
+        }
+      }
+    },
+    [password, apiBaseUrl, backoffUntil, state]
+  );
+
+  const handleFailure = useCallback(
+    (message: string) => {
+      const newCount = failureCount + 1;
+      setFailureCount(newCount);
+
+      if (newCount >= MAX_FAILURES_BEFORE_BACKOFF) {
+        const backoffMs = Math.min(
+          BASE_BACKOFF_MS * Math.pow(2, newCount - MAX_FAILURES_BEFORE_BACKOFF),
+          MAX_BACKOFF_MS
+        );
+        setBackoffUntil(Date.now() + backoffMs);
+      }
+
+      setState({ step: 'error', message });
+    },
+    [failureCount]
+  );
+
+  const handleRetry = useCallback(() => {
+    setPassword('');
+    setState({ step: 'password' });
+  }, []);
+
+  // --- Render ---
+
+  if (state.step === 'loading') {
+    return (
+      <div style={{ padding: '2rem', textAlign: 'center' }}>
+        <p>Loading share...</p>
+      </div>
+    );
+  }
+
+  if (state.step === 'done') {
+    return (
+      <div style={{ padding: '2rem', textAlign: 'center' }}>
+        <h2>Download Complete</h2>
+        <p>
+          <strong>{state.fileName}</strong> has been decrypted and downloaded.
+        </p>
+      </div>
+    );
+  }
+
+  if (state.step === 'error') {
+    return (
+      <div style={{ padding: '2rem' }}>
+        <h2>Share Access</h2>
+        <p style={{ color: 'red' }}>{state.message}</p>
+        {shareIdRef.current && (
+          <button type="button" onClick={handleRetry}>
+            Try Again
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  if (state.step === 'decrypting') {
+    return (
+      <div style={{ padding: '2rem', textAlign: 'center' }}>
+        <h2>Decrypting...</h2>
+        <p>Deriving keys and decrypting file. This may take a moment.</p>
+      </div>
+    );
+  }
+
+  // step === 'password'
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h2>Shared File Access</h2>
+      <p>Enter the password to decrypt and download this shared file.</p>
+
+      <form onSubmit={handleSubmit}>
+        <div style={{ marginBottom: '1rem' }}>
+          <label htmlFor="access-password">Password</label>
+          <input
+            id="access-password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            autoFocus
+            style={{ display: 'block', width: '100%', marginTop: '0.25rem' }}
+          />
+        </div>
+
+        {backoffUntil && Date.now() < backoffUntil && (
+          <p style={{ color: '#996600', fontSize: '0.85rem' }}>
+            Rate limited. Please wait before trying again.
+          </p>
+        )}
+
+        <button type="submit" disabled={!password}>
+          Decrypt &amp; Download
+        </button>
+      </form>
+    </div>
+  );
+}
+
+/** Convert base64 string to Uint8Array */
+function base64ToUint8(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}

--- a/packages/web/src/components/ShareCreate.tsx
+++ b/packages/web/src/components/ShareCreate.tsx
@@ -1,0 +1,254 @@
+import { useState, useCallback } from 'react';
+import {
+  deriveShareKeys,
+  computeShareHmac,
+  encodeShareBlob,
+  unwrapDek,
+  wrapDek,
+} from '@cortex/encryption';
+
+/** Expiration option for share links */
+interface ExpirationOption {
+  label: string;
+  value: number | null; // seconds from now, or null for never
+}
+
+const EXPIRATION_OPTIONS: ExpirationOption[] = [
+  { label: 'Never', value: null },
+  { label: '1 hour', value: 3600 },
+  { label: '1 day', value: 86400 },
+  { label: '7 days', value: 604800 },
+  { label: '30 days', value: 2592000 },
+];
+
+const MIN_PASSWORD_LENGTH = 16;
+const SALT_SIZE = 16;
+const BLOB_VERSION = 0x01;
+
+interface ShareCreateProps {
+  itemId: string;
+  wrappedDek: Uint8Array;
+  vaultKek: Uint8Array;
+  apiBaseUrl: string;
+}
+
+interface ShareResult {
+  shareUrl: string;
+  shareId: string;
+}
+
+export function ShareCreate({
+  itemId,
+  wrappedDek,
+  vaultKek,
+  apiBaseUrl,
+}: ShareCreateProps) {
+  const [password, setPassword] = useState('');
+  const [expirationIndex, setExpirationIndex] = useState(0);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<ShareResult | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const isPasswordValid = password.length >= MIN_PASSWORD_LENGTH;
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!isPasswordValid || isSubmitting) return;
+
+      setIsSubmitting(true);
+      setError(null);
+      setResult(null);
+
+      try {
+        // 1. Generate random salt
+        const salt = crypto.getRandomValues(new Uint8Array(SALT_SIZE));
+
+        // 2. Derive share encryption + HMAC keys from password + salt
+        const shareKeys = await deriveShareKeys(password, salt);
+
+        // 3. Unwrap the file DEK using vault KEK
+        const dek = unwrapDek(wrappedDek, vaultKek);
+
+        // 4. Re-wrap the DEK with the share encryption key
+        const shareWrappedDek = await wrapDek(dek, shareKeys.encryptionKey);
+
+        // Zero the plaintext DEK
+        dek.fill(0);
+
+        // 5. Compute expiration
+        const selectedExpiration = EXPIRATION_OPTIONS[expirationIndex];
+        const expiresAt = selectedExpiration.value
+          ? Math.floor(Date.now() / 1000) + selectedExpiration.value
+          : undefined;
+
+        // 6. POST /v1/shares to create the share record
+        const response = await fetch(`${apiBaseUrl}/v1/shares`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            itemId,
+            wrappedDek: uint8ToBase64(shareWrappedDek),
+            expiresAt: expiresAt ?? null,
+          }),
+        });
+
+        if (!response.ok) {
+          const body = await response.text();
+          throw new Error(`Failed to create share: ${response.status} ${body}`);
+        }
+
+        const { shareId } = (await response.json()) as { shareId: string };
+
+        // 7. Compute HMAC over shareId (and optional expiry)
+        const hmacValue = computeShareHmac(
+          shareKeys.hmacKey,
+          shareId,
+          expiresAt
+        );
+
+        // 8. Encode the share blob
+        const blob = encodeShareBlob(
+          BLOB_VERSION,
+          salt,
+          shareWrappedDek,
+          hmacValue
+        );
+
+        // 9. Construct share URL with blob in fragment
+        const origin = window.location.origin;
+        const shareUrl = `${origin}/s/${shareId}#${blob}`;
+
+        // Zero keys
+        shareKeys.encryptionKey.fill(0);
+        shareKeys.hmacKey.fill(0);
+
+        setResult({ shareUrl, shareId });
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : 'An unexpected error occurred'
+        );
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [password, isPasswordValid, isSubmitting, expirationIndex, itemId, wrappedDek, vaultKek, apiBaseUrl]
+  );
+
+  const handleCopy = useCallback(async () => {
+    if (!result) return;
+    try {
+      await navigator.clipboard.writeText(result.shareUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback: select the text in the input
+      const input = document.querySelector<HTMLInputElement>(
+        '[data-testid="share-url-input"]'
+      );
+      if (input) {
+        input.select();
+      }
+    }
+  }, [result]);
+
+  // --- Result view ---
+  if (result) {
+    return (
+      <div style={{ padding: '1rem' }}>
+        <h3>Share Link Created</h3>
+
+        <div style={{ marginBottom: '0.5rem' }}>
+          <label htmlFor="share-url">Share URL</label>
+          <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.25rem' }}>
+            <input
+              id="share-url"
+              data-testid="share-url-input"
+              type="text"
+              readOnly
+              value={result.shareUrl}
+              style={{ flex: 1, fontFamily: 'monospace', fontSize: '0.85rem' }}
+              onClick={(e) => (e.target as HTMLInputElement).select()}
+            />
+            <button type="button" onClick={handleCopy}>
+              {copied ? 'Copied!' : 'Copy'}
+            </button>
+          </div>
+        </div>
+
+        <p style={{ fontSize: '0.85rem', color: '#666' }}>
+          Share ID: <code>{result.shareId}</code>
+        </p>
+
+        <p style={{ fontSize: '0.8rem', color: '#996600' }}>
+          Warning: Do not use URL shorteners -- the fragment (after #) contains
+          encrypted key material and may be stripped by some services.
+        </p>
+      </div>
+    );
+  }
+
+  // --- Form view ---
+  return (
+    <form onSubmit={handleSubmit} style={{ padding: '1rem' }}>
+      <h3>Create Share Link</h3>
+
+      <div style={{ marginBottom: '1rem' }}>
+        <label htmlFor="share-password">
+          Password (minimum {MIN_PASSWORD_LENGTH} characters)
+        </label>
+        <input
+          id="share-password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          minLength={MIN_PASSWORD_LENGTH}
+          required
+          style={{ display: 'block', width: '100%', marginTop: '0.25rem' }}
+          disabled={isSubmitting}
+        />
+        {password.length > 0 && !isPasswordValid && (
+          <p style={{ color: 'red', fontSize: '0.85rem', margin: '0.25rem 0 0' }}>
+            Password must be at least {MIN_PASSWORD_LENGTH} characters
+            ({password.length}/{MIN_PASSWORD_LENGTH})
+          </p>
+        )}
+      </div>
+
+      <div style={{ marginBottom: '1rem' }}>
+        <label htmlFor="share-expiration">Expiration</label>
+        <select
+          id="share-expiration"
+          value={expirationIndex}
+          onChange={(e) => setExpirationIndex(Number(e.target.value))}
+          style={{ display: 'block', marginTop: '0.25rem' }}
+          disabled={isSubmitting}
+        >
+          {EXPIRATION_OPTIONS.map((opt, i) => (
+            <option key={i} value={i}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {error && (
+        <p style={{ color: 'red', marginBottom: '1rem' }}>{error}</p>
+      )}
+
+      <button type="submit" disabled={!isPasswordValid || isSubmitting}>
+        {isSubmitting ? 'Creating...' : 'Create Share Link'}
+      </button>
+    </form>
+  );
+}
+
+/** Convert Uint8Array to standard base64 */
+function uint8ToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}

--- a/packages/web/src/components/ShareCreate.tsx
+++ b/packages/web/src/components/ShareCreate.tsx
@@ -22,8 +22,23 @@ const EXPIRATION_OPTIONS: ExpirationOption[] = [
 ];
 
 const MIN_PASSWORD_LENGTH = 16;
+const MIN_ENTROPY_BITS = 80;
 const SALT_SIZE = 16;
 const BLOB_VERSION = 0x01;
+
+/**
+ * Estimate Shannon entropy of a password in bits.
+ * Counts unique character classes and uses charset size * length.
+ */
+function estimatePasswordEntropy(password: string): number {
+  let charsetSize = 0;
+  if (/[a-z]/.test(password)) charsetSize += 26;
+  if (/[A-Z]/.test(password)) charsetSize += 26;
+  if (/[0-9]/.test(password)) charsetSize += 10;
+  if (/[^a-zA-Z0-9]/.test(password)) charsetSize += 32;
+  if (charsetSize === 0) return 0;
+  return Math.floor(password.length * Math.log2(charsetSize));
+}
 
 interface ShareCreateProps {
   itemId: string;
@@ -50,7 +65,8 @@ export function ShareCreate({
   const [result, setResult] = useState<ShareResult | null>(null);
   const [copied, setCopied] = useState(false);
 
-  const isPasswordValid = password.length >= MIN_PASSWORD_LENGTH;
+  const passwordEntropy = estimatePasswordEntropy(password);
+  const isPasswordValid = password.length >= MIN_PASSWORD_LENGTH && passwordEntropy >= MIN_ENTROPY_BITS;
 
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
@@ -88,9 +104,8 @@ export function ShareCreate({
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            itemId,
-            wrappedDek: uint8ToBase64(shareWrappedDek),
-            expiresAt: expiresAt ?? null,
+            item_id: itemId,
+            expires_at: expiresAt ?? null,
           }),
         });
 
@@ -99,7 +114,7 @@ export function ShareCreate({
           throw new Error(`Failed to create share: ${response.status} ${body}`);
         }
 
-        const { shareId } = (await response.json()) as { shareId: string };
+        const { share_id: shareId } = (await response.json()) as { share_id: string };
 
         // 7. Compute HMAC over shareId (and optional expiry)
         const hmacValue = computeShareHmac(
@@ -210,8 +225,9 @@ export function ShareCreate({
         />
         {password.length > 0 && !isPasswordValid && (
           <p style={{ color: 'red', fontSize: '0.85rem', margin: '0.25rem 0 0' }}>
-            Password must be at least {MIN_PASSWORD_LENGTH} characters
-            ({password.length}/{MIN_PASSWORD_LENGTH})
+            {password.length < MIN_PASSWORD_LENGTH
+              ? `Password must be at least ${MIN_PASSWORD_LENGTH} characters (${password.length}/${MIN_PASSWORD_LENGTH})`
+              : `Password too weak — use a mix of upper/lowercase, numbers, and symbols (${passwordEntropy}/${MIN_ENTROPY_BITS} bits)`}
           </p>
         )}
       </div>
@@ -242,13 +258,4 @@ export function ShareCreate({
       </button>
     </form>
   );
-}
-
-/** Convert Uint8Array to standard base64 */
-function uint8ToBase64(bytes: Uint8Array): string {
-  let binary = '';
-  for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binary);
 }


### PR DESCRIPTION
## Summary

- Implement password-protected file sharing with envelope encryption (task 17.1-17.5)
- Server never sees key material — all crypto operations happen client-side
- Recipients access shared files using only the share password, no vault password needed

## Changes

**Encryption library** (`packages/encryption/`)
- `share-encryption.ts`: Key derivation (Argon2id + HKDF), HMAC metadata binding, base64url blob encode/decode
- Property test 20: Share keys enable file access without vault password (50 runs)
- Unit tests: 30 test cases covering deriveShareKeys, HMAC, blob round-trip

**Backend** (`lambda/`)
- `ShareService`: create, get, revoke shares with per-IP rate limiting (5/hr/share)
- Route handlers: POST/GET/DELETE /v1/shares wired to ShareService
- DynamoDB TTL for auto-cleanup of expired/revoked shares and rate limit rows
- Pydantic models: CreateShareRequest/Response, GetShareResponse, RevokeShareResponse
- 292 tests passing, 86.29% coverage

**Frontend** (`packages/web/`)
- `ShareCreate.tsx`: Password input, expiration picker, DEK re-wrapping, URL construction
- `ShareAccess.tsx`: HMAC verification, DEK unwrapping, file decryption, client-side rate limiting
- `/s/{shareId}` routing in App.tsx

**Infrastructure** (`cdk/`)
- DynamoDB TTL enabled on shares table
- Fixed CDK Lambda env var mismatches (DATA_TABLE → ITEMS_TABLE_NAME, etc.)

## Design

Design doc: `docs/plans/2026-02-06-file-sharing-design.md`

- Share URL: `https://app.cortex.dev/s/{shareId}#{base64url_blob}` (opaque blob, fragment never sent to server)
- Blob format: `[version(1)][salt(16)][wrappedDek(65)][hmac(32)]` = 114 bytes
- Three-layer rate limiting: API Gateway throttling, server-side DynamoDB tracking, client-side exponential backoff
- TTL cleanup: expired shares (24h grace), revoked shares (7d audit), rate limit rows (2h)

## Test plan

- [x] Python tests pass (292/292, 86.29% coverage)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] black, isort, flake8 pass
- [x] CDK synth succeeds
- [ ] Manual: create share, access share with correct/wrong password
- [ ] Manual: verify expired/revoked shares return proper errors