### PR TITLE
fix(encryption): wire deriveKeys KEK into envelope encryption (task 6.2)

### DIFF
--- a/packages/encryption/src/lib/key-management.ts
+++ b/packages/encryption/src/lib/key-management.ts
@@ -134,7 +134,8 @@ async function getArgon2id() {
  * - Master key is already high-entropy (Argon2id with 64MB memory, 3 iterations)
  */
 const HKDF_SALTS = {
-  DATA_ENCRYPTION: new TextEncoder().encode('cortex-salt-data-v1'),
+  // ponytail: KEK salt is versioned (-v1); key rotation (task 6.13) bumps to -v2, -v3…
+  KEY_ENCRYPTION: new TextEncoder().encode('cortex-salt-kek-v1'),
   METADATA_ENCRYPTION: new TextEncoder().encode('cortex-salt-metadata-v1'),
   SHARE_KEY_DERIVATION: new TextEncoder().encode('cortex-salt-share-v1'),
   NOTES_ENCRYPTION: new TextEncoder().encode('cortex-salt-notes-v1'),
@@ -152,7 +153,9 @@ const HKDF_SALTS = {
  * Combined with HKDF_SALTS, this provides two independent layers of separation.
  */
 const HKDF_CONTEXTS = {
-  DATA_ENCRYPTION: 'cortex-data-encryption-v1',
+  // Key Encryption Key — wraps per-file DEKs (envelope encryption). Context is
+  // versioned for key rotation: v1 today, v2/v3… after a rotation (task 6.13).
+  KEY_ENCRYPTION: 'cortex-kek-v1',
   METADATA_ENCRYPTION: 'cortex-metadata-encryption-v1',
   SHARE_KEY_DERIVATION: 'cortex-share-key-derivation-v1',
   NOTES_ENCRYPTION: 'cortex-notes-encryption-v1',
@@ -161,6 +164,10 @@ const HKDF_CONTEXTS = {
   NOTIFICATION_ENCRYPTION: 'cortex-notification-encryption-v1',
   DATE_BUCKET_ENCRYPTION: 'cortex-date-bucket-encryption-v1',
   SALT_HMAC: 'cortex-salt-hmac-v1',
+  // ponytail: spec 6.2 also lists a vault-level "share metadata HMAC key" — deferred,
+  // nothing consumes one yet. When built, it must NOT reuse 'cortex-share-hmac-v1'
+  // (share-encryption.ts already uses that for a share-password-derived key); pick a
+  // domain-separated context, e.g. 'cortex-vault-share-metadata-hmac-v1'.
 };
 
 /**
@@ -214,7 +221,8 @@ export async function deriveVaultMasterKey(
  * Interface representing all derived encryption keys for a vault
  */
 export interface DerivedKeys {
-  dataEncryptionKey: Uint8Array;
+  /** Key Encryption Key (KEK): wraps per-file DEKs for envelope encryption. */
+  keyEncryptionKey: Uint8Array;
   metadataEncryptionKey: Uint8Array;
   shareKeyDerivationKey: Uint8Array;
   notesEncryptionKey: Uint8Array;
@@ -238,7 +246,7 @@ export interface DerivedKeys {
  * @example
  * const masterKey = await deriveVaultMasterKey(password, salt);
  * const keys = deriveKeys(masterKey);
- * // Use keys.dataEncryptionKey for encrypting file content
+ * // Use keys.keyEncryptionKey as the KEK to wrap per-file DEKs (envelope encryption)
  * // Use keys.metadataEncryptionKey for encrypting metadata
  */
 export function deriveKeys(vaultMasterKey: Uint8Array): DerivedKeys {
@@ -250,11 +258,11 @@ export function deriveKeys(vaultMasterKey: Uint8Array): DerivedKeys {
 
   try {
     return {
-      dataEncryptionKey: hkdf(
+      keyEncryptionKey: hkdf(
         sha256,
         vaultMasterKey,
-        HKDF_SALTS.DATA_ENCRYPTION,
-        new TextEncoder().encode(HKDF_CONTEXTS.DATA_ENCRYPTION),
+        HKDF_SALTS.KEY_ENCRYPTION,
+        new TextEncoder().encode(HKDF_CONTEXTS.KEY_ENCRYPTION),
         keyLength
       ),
       metadataEncryptionKey: hkdf(
@@ -378,7 +386,7 @@ export function generateRecoveryKey(vaultMasterKey: Uint8Array): string {
  * const recoveryKey = 'word1 word2 word3 ... word24';
  * const recoveredMasterKey = validateRecoveryKey(recoveryKey);
  * const keys = deriveKeys(recoveredMasterKey);
- * // Now you can decrypt vault data with keys.dataEncryptionKey, etc.
+ * // Now you can decrypt vault data with keys.keyEncryptionKey, etc.
  */
 export function validateRecoveryKey(recoveryKey: string): Uint8Array {
   if (!recoveryKey || typeof recoveryKey !== 'string') {

--- a/packages/encryption/src/lib/key-storage.ts
+++ b/packages/encryption/src/lib/key-storage.ts
@@ -101,7 +101,7 @@ interface StoredKeyData {
  * Interface for keys to be stored
  */
 export interface KeysToStore {
-  dataEncryptionKey: Uint8Array;
+  keyEncryptionKey: Uint8Array;
   metadataEncryptionKey: Uint8Array;
   shareKeyDerivationKey: Uint8Array;
   notesEncryptionKey: Uint8Array;
@@ -1060,7 +1060,7 @@ export async function clearSaltHmacRecord(
  */
 function serializeKeys(keys: KeysToStore): string {
   const serializable: Record<string, unknown> = {
-    dataEncryptionKey: Array.from(keys.dataEncryptionKey),
+    keyEncryptionKey: Array.from(keys.keyEncryptionKey),
     metadataEncryptionKey: Array.from(keys.metadataEncryptionKey),
     shareKeyDerivationKey: Array.from(keys.shareKeyDerivationKey),
     notesEncryptionKey: Array.from(keys.notesEncryptionKey),
@@ -1083,7 +1083,7 @@ function deserializeKeys(json: string): KeysToStore {
   const parsed = JSON.parse(json);
 
   const result: KeysToStore = {
-    dataEncryptionKey: new Uint8Array(parsed.dataEncryptionKey),
+    keyEncryptionKey: new Uint8Array(parsed.keyEncryptionKey),
     metadataEncryptionKey: new Uint8Array(parsed.metadataEncryptionKey),
     shareKeyDerivationKey: new Uint8Array(parsed.shareKeyDerivationKey),
     notesEncryptionKey: new Uint8Array(parsed.notesEncryptionKey),

--- a/packages/encryption/tests/property/test_key_management.test.ts
+++ b/packages/encryption/tests/property/test_key_management.test.ts
@@ -70,7 +70,7 @@ describe('Key Management Property Tests', () => {
             const keys2 = deriveKeys(masterKey);
             
             // All derived keys must be identical
-            expect(keys1.dataEncryptionKey).toEqual(keys2.dataEncryptionKey);
+            expect(keys1.keyEncryptionKey).toEqual(keys2.keyEncryptionKey);
             expect(keys1.metadataEncryptionKey).toEqual(keys2.metadataEncryptionKey);
             expect(keys1.shareKeyDerivationKey).toEqual(keys2.shareKeyDerivationKey);
             expect(keys1.notesEncryptionKey).toEqual(keys2.notesEncryptionKey);
@@ -81,7 +81,7 @@ describe('Key Management Property Tests', () => {
             expect(keys1.saltHmacKey).toEqual(keys2.saltHmacKey);
 
             // All keys must be 32 bytes (256 bits)
-            expect(keys1.dataEncryptionKey.length).toBe(32);
+            expect(keys1.keyEncryptionKey.length).toBe(32);
             expect(keys1.metadataEncryptionKey.length).toBe(32);
             expect(keys1.shareKeyDerivationKey.length).toBe(32);
             expect(keys1.notesEncryptionKey.length).toBe(32);
@@ -105,7 +105,7 @@ describe('Key Management Property Tests', () => {
             
             // All derived keys must be different from each other
             const allKeys = [
-              keys.dataEncryptionKey,
+              keys.keyEncryptionKey,
               keys.metadataEncryptionKey,
               keys.shareKeyDerivationKey,
               keys.notesEncryptionKey,
@@ -260,8 +260,8 @@ describe('Key Management Property Tests', () => {
             const keys3 = deriveKeys(masterKey);
             
             // All derivations must produce identical keys
-            expect(keys1.dataEncryptionKey).toEqual(keys2.dataEncryptionKey);
-            expect(keys2.dataEncryptionKey).toEqual(keys3.dataEncryptionKey);
+            expect(keys1.keyEncryptionKey).toEqual(keys2.keyEncryptionKey);
+            expect(keys2.keyEncryptionKey).toEqual(keys3.keyEncryptionKey);
             
             expect(keys1.metadataEncryptionKey).toEqual(keys2.metadataEncryptionKey);
             expect(keys2.metadataEncryptionKey).toEqual(keys3.metadataEncryptionKey);
@@ -286,7 +286,7 @@ describe('Key Management Property Tests', () => {
             const keys2 = deriveKeys(masterKey2);
             
             // Different master keys must produce different derived keys
-            expect(keys1.dataEncryptionKey).not.toEqual(keys2.dataEncryptionKey);
+            expect(keys1.keyEncryptionKey).not.toEqual(keys2.keyEncryptionKey);
             expect(keys1.metadataEncryptionKey).not.toEqual(keys2.metadataEncryptionKey);
             expect(keys1.shareKeyDerivationKey).not.toEqual(keys2.shareKeyDerivationKey);
           }
@@ -304,7 +304,7 @@ describe('Key Management Property Tests', () => {
             
             // Collect all derived keys
             const allKeys = [
-              keys.dataEncryptionKey,
+              keys.keyEncryptionKey,
               keys.metadataEncryptionKey,
               keys.shareKeyDerivationKey,
               keys.notesEncryptionKey,
@@ -351,7 +351,7 @@ describe('Key Management Property Tests', () => {
               expect(uniqueBytes).toBeGreaterThan(10); // At least 10 different byte values
             };
             
-            checkEntropy(keys.dataEncryptionKey);
+            checkEntropy(keys.keyEncryptionKey);
             checkEntropy(keys.metadataEncryptionKey);
             checkEntropy(keys.shareKeyDerivationKey);
           }
@@ -385,7 +385,7 @@ describe('Key Management Property Tests', () => {
       const keys = deriveKeys(masterKey);
       
       const masterKeyStr = Array.from(masterKey).join(',');
-      const dataKeyStr = Array.from(keys.dataEncryptionKey).join(',');
+      const dataKeyStr = Array.from(keys.keyEncryptionKey).join(',');
       
       try {
         deriveKeys(new Uint8Array(16)); // Invalid key size
@@ -414,7 +414,7 @@ describe('Key Management Property Tests', () => {
             expect(jsonStr.length).toBeGreaterThan(0);
             
             // Verify that the keys object structure is preserved
-            expect(jsonStr).toContain('dataEncryptionKey');
+            expect(jsonStr).toContain('keyEncryptionKey');
             expect(jsonStr).toContain('metadataEncryptionKey');
           }
         ),

--- a/packages/encryption/tests/unit/kek-wiring.test.ts
+++ b/packages/encryption/tests/unit/kek-wiring.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Wiring test for task 6.2: deriveKeys() must produce the Key Encryption Key (KEK)
+ * that envelope encryption (wrapDek/unwrapDek) consumes.
+ *
+ * Under envelope encryption each file is encrypted with a per-file random DEK, and
+ * that DEK is wrapped by a vault-level KEK. Before this fix deriveKeys() produced a
+ * `dataEncryptionKey` (context "cortex-data-encryption-v1") that nothing consumed,
+ * while wrapDek/unwrapDek took a `kek` parameter that deriveKeys never produced.
+ * This test proves the loop is closed: the KEK from deriveKeys() actually wraps and
+ * unwraps a file's DEK.
+ */
+
+import { deriveKeys } from '../../src/lib/key-management';
+import { encryptFileWithDek, decryptFileWithDek } from '../../src/lib/envelope-encryption';
+
+describe('KEK wiring (task 6.2)', () => {
+  const mockMasterKey = (): Uint8Array => {
+    const k = new Uint8Array(32);
+    crypto.getRandomValues(k);
+    return k;
+  };
+
+  it('exposes a 32-byte keyEncryptionKey', () => {
+    const keys = deriveKeys(mockMasterKey());
+    expect(keys.keyEncryptionKey).toBeInstanceOf(Uint8Array);
+    expect(keys.keyEncryptionKey.length).toBe(32);
+  });
+
+  it('the derived KEK round-trips a file through envelope encryption', async () => {
+    const keys = deriveKeys(mockMasterKey());
+    const content = new TextEncoder().encode('zero-knowledge file payload');
+
+    const { encryptedContent, wrappedDek } = await encryptFileWithDek(
+      content,
+      keys.keyEncryptionKey,
+      'file-123'
+    );
+    const decrypted = decryptFileWithDek(
+      encryptedContent,
+      wrappedDek,
+      keys.keyEncryptionKey,
+      'file-123'
+    );
+
+    expect(decrypted).toEqual(content);
+  });
+});

--- a/packages/encryption/tests/unit/key-management.test.ts
+++ b/packages/encryption/tests/unit/key-management.test.ts
@@ -27,8 +27,8 @@ describe('Key Management', () => {
 
       const keys = deriveKeys(masterKey);
 
-      expect(keys.dataEncryptionKey).toBeInstanceOf(Uint8Array);
-      expect(keys.dataEncryptionKey.length).toBe(32);
+      expect(keys.keyEncryptionKey).toBeInstanceOf(Uint8Array);
+      expect(keys.keyEncryptionKey.length).toBe(32);
       expect(keys.metadataEncryptionKey).toBeInstanceOf(Uint8Array);
       expect(keys.metadataEncryptionKey.length).toBe(32);
       expect(keys.shareKeyDerivationKey).toBeInstanceOf(Uint8Array);
@@ -52,7 +52,7 @@ describe('Key Management', () => {
 
       // All keys should be different from each other
       const keyArray = [
-        keys.dataEncryptionKey,
+        keys.keyEncryptionKey,
         keys.metadataEncryptionKey,
         keys.shareKeyDerivationKey,
         keys.notesEncryptionKey,
@@ -75,7 +75,7 @@ describe('Key Management', () => {
       const keys1 = deriveKeys(masterKey);
       const keys2 = deriveKeys(masterKey);
 
-      expect(keys1.dataEncryptionKey).toEqual(keys2.dataEncryptionKey);
+      expect(keys1.keyEncryptionKey).toEqual(keys2.keyEncryptionKey);
       expect(keys1.metadataEncryptionKey).toEqual(keys2.metadataEncryptionKey);
       expect(keys1.shareKeyDerivationKey).toEqual(keys2.shareKeyDerivationKey);
       expect(keys1.notesEncryptionKey).toEqual(keys2.notesEncryptionKey);
@@ -100,7 +100,7 @@ describe('Key Management', () => {
       expect(keys.saltHmacKey).toHaveLength(32);
 
       const others = [
-        keys.dataEncryptionKey,
+        keys.keyEncryptionKey,
         keys.metadataEncryptionKey,
         keys.shareKeyDerivationKey,
         keys.notesEncryptionKey,

--- a/packages/encryption/tests/unit/key-storage-concurrency.test.ts
+++ b/packages/encryption/tests/unit/key-storage-concurrency.test.ts
@@ -226,7 +226,7 @@ Object.defineProperty(global, 'localStorage', {
 // Helper to create test keys
 function createTestKeys(seed: number = 1): KeysToStore {
   return {
-    dataEncryptionKey: new Uint8Array(32).fill(seed),
+    keyEncryptionKey: new Uint8Array(32).fill(seed),
     metadataEncryptionKey: new Uint8Array(32).fill(seed + 1),
     shareKeyDerivationKey: new Uint8Array(32).fill(seed + 2),
     notesEncryptionKey: new Uint8Array(32).fill(seed + 3),

--- a/packages/encryption/tests/unit/key-storage-secure.test.ts
+++ b/packages/encryption/tests/unit/key-storage-secure.test.ts
@@ -180,7 +180,7 @@ Object.defineProperty(global, 'sessionStorage', {
 // Helper to create test keys
 function createTestKeys(): KeysToStore {
   return {
-    dataEncryptionKey: new Uint8Array(32).fill(1),
+    keyEncryptionKey: new Uint8Array(32).fill(1),
     metadataEncryptionKey: new Uint8Array(32).fill(2),
     shareKeyDerivationKey: new Uint8Array(32).fill(3),
     notesEncryptionKey: new Uint8Array(32).fill(4),
@@ -273,7 +273,7 @@ describe('Key Storage (IndexedDB + Web Crypto API)', () => {
       const retrieved = await retrieveKeys('vault-123', config);
       
       expect(retrieved).not.toBeNull();
-      expect(retrieved!.dataEncryptionKey).toEqual(keys.dataEncryptionKey);
+      expect(retrieved!.keyEncryptionKey).toEqual(keys.keyEncryptionKey);
       expect(retrieved!.metadataEncryptionKey).toEqual(keys.metadataEncryptionKey);
     });
 


### PR DESCRIPTION
## What & why

Task 6.2 was a **foundational wiring gap**: `deriveKeys()` produced a vestigial `dataEncryptionKey` (HKDF context `cortex-data-encryption-v1`) that nothing consumed, while the envelope layer's `wrapDek`/`unwrapDek` required a **KEK** that `deriveKeys` never produced. The web app's file-encryption path (task 7.3) would have hit this immediately.

Under envelope encryption, file content is encrypted with a per-file random **DEK**; the vault-level key's only job is to *wrap* those DEKs — that job **is** the KEK. So the fix renames the orphan key into the real KEK rather than adding a second key.

## Changes
- **`key-management.ts`**: `dataEncryptionKey` → `keyEncryptionKey`; context `cortex-data-encryption-v1` → `cortex-kek-v1`; salt `cortex-salt-data-v1` → `cortex-salt-kek-v1` (both versioned for key rotation, task 6.13)
- **`key-storage.ts`**: `KeysToStore` interface + serialize/deserialize follow the rename
- **`tests/unit/kek-wiring.test.ts`** (new): proves `deriveKeys().keyEncryptionKey` round-trips a file through `encryptFileWithDek`/`decryptFileWithDek` — the loop the old code left open

## Verification
- TDD: watched the wiring test fail (`undefined` KEK reaching `wrapDek`) → green
- Full encryption suite: **193 passed, 0 failed, 9 skipped**; `tsc` build clean
- 3-lens adversarial review (crypto / regression / spec) all **pass**: the KEK's `(salt, info)` pair collides with none of the 11 other keys across `key-management` + `share-encryption`; zero stale code consumers repo-wide

## Deliberately deferred
Spec 6.2 also lists a vault-level "share metadata HMAC key" — **skipped** because nothing consumes one and `share-encryption.ts` already uses `cortex-share-hmac-v1` for a share-password-derived key. An in-code `ponytail:` comment warns the future implementer to pick a domain-separated context (not the bare `cortex-share-hmac-v1`) if it's ever built.

## Note
Unblocks **Phase B / task 7.3**: the web app can now call `encryptFileWithDek(content, keys.keyEncryptionKey, fileId)` with a real KEK behind it.