### PR TITLE
ci: run TypeScript unit tests (jest + vitest) in GitHub Actions

### DIFF
--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -1,0 +1,44 @@
+name: js-tests
+
+on:
+  push:
+    paths:
+      - '.github/workflows/js-tests.yml'
+      - 'packages/**'
+      - 'package.json'
+      - 'package-lock.json'
+    branches: [ "mainline" ]
+  pull_request:
+    paths:
+      - '.github/workflows/js-tests.yml'
+      - 'packages/**'
+      - 'package.json'
+      - 'package-lock.json'
+    branches: [ "mainline" ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      # Single workspace install — covers @cortex/encryption and @cortex/web.
+      - name: Install dependencies
+        run: npm ci
+
+      # Runs test:encryption (jest) then test:web (vitest --passWithNoTests).
+      # web has no tests yet; it starts gating automatically once Phase B adds them.
+      - name: Run TypeScript/JS unit tests
+        run: npm run test:all

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "test": "vitest --run",
+    "test": "vitest --run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest --coverage"
   },


### PR DESCRIPTION
## What & why

No CI currently runs any TypeScript/JS tests:
- `lambda-tests.yml` → pytest only
- `cdk-build.yml` → only `npm ci` + `npm run build` + `cdk synth` in `cdk/`, runs zero tests, and its `pull_request` path filter excludes `packages/**`
- `codeql.yml` → security static analysis

So `@cortex/encryption`'s jest suite (and the upcoming `@cortex/web` vitest suite) were validated **locally only** — a PR touching `packages/**` got no test gate at all.

## Change
New `js-tests.yml`: on changes to `packages/**` or the root manifest, one workspace `npm ci` → `npm run test:all` (jest for encryption, vitest for web). Mirrors the repo's existing workflow conventions (pinned Node 24, `contents: read`, npm cache).

`@cortex/web` has no test files yet, so its `test` script gains `--passWithNoTests` — CI is green today and **auto-gates web the moment Phase B adds the first test**, no workflow edit needed.

## Verification
Ran the exact CI command locally: `npm run test:all` → encryption **191 passed, 9 skipped**, web exits 0 (no test files). No untrusted input used in the workflow (no `${{ github.event.* }}` in `run:`).

## Note
Independent of #205 (the 6.2 KEK fix). Once both merge, this workflow will also run #205's new `kek-wiring.test.ts`.