### PR TITLE
feat(web): Phase B Slice 1 — auth foundation (Cognito + vault unlock)

### DIFF
--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -38,7 +38,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Runs test:encryption (jest) then test:web (vitest --passWithNoTests).
-      # web has no tests yet; it starts gating automatically once Phase B adds them.
+      # Build @cortex/encryption first: @cortex/web imports its compiled dist
+      # (package main: dist/index.js), which a fresh `npm ci` does not produce.
+      - name: Build encryption package
+        run: npm run build:encryption
+
+      # Runs test:encryption (jest) then test:web (vitest).
       - name: Run TypeScript/JS unit tests
         run: npm run test:all

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,850 @@
         "packages/*"
       ]
     },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws-amplify/analytics": {
+      "version": "7.0.94",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-7.0.94.tgz",
+      "integrity": "sha512-HNBq12e+ZFY7EqqlK2sAX165Vp5M4bx40a26f8ej6bDolZG5kkn4cYmERQX8LaWp0iVpfNUWAWPEppwZiLMMcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-firehose": "^3.1012.0",
+        "@aws-sdk/client-kinesis": "^3.1012.0",
+        "@aws-sdk/client-personalize-events": "^3.1012.0",
+        "@smithy/util-utf8": "2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "peerDependencies": {
+        "@aws-amplify/core": "^6.16.2"
+      }
+    },
+    "node_modules/@aws-amplify/api": {
+      "version": "6.3.27",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.3.27.tgz",
+      "integrity": "sha512-N9lOAWbUFTiSzz5M5TukBTwGLetdFeXZT/588I8Q5/3d4NGmc2J1EGDg33CfPXhWTaMETTMiNITbAlIl2XEZCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/api-graphql": "4.8.8",
+        "@aws-amplify/api-rest": "4.6.4",
+        "@aws-amplify/data-schema": "^1.7.0",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.0"
+      },
+      "peerDependencies": {
+        "@aws-amplify/core": "^6.16.2"
+      }
+    },
+    "node_modules/@aws-amplify/api-graphql": {
+      "version": "4.8.8",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.8.8.tgz",
+      "integrity": "sha512-HaxeQaDQu67TNSMvrqLfy8uA5e5w3ENzePIlKjsHja+vE63dO1nGEDh5ajJKLUfbKwi2K3s1IK7F0zZmhwX6Cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/api-rest": "4.6.4",
+        "@aws-amplify/core": "6.16.4",
+        "@aws-amplify/data-schema": "^1.7.0",
+        "@aws-sdk/types": "^3.973.6",
+        "graphql": "15.8.0",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-amplify/api-rest": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.6.4.tgz",
+      "integrity": "sha512-/gGTP2/vWKma6ApVG56y9/1qh2/i4hDp37sm1zRSM0EMNdKr5RIgHbQ0W1l1gaJHRmPXb2lqUDfj9ZYFQATjQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "peerDependencies": {
+        "@aws-amplify/core": "^6.16.2"
+      }
+    },
+    "node_modules/@aws-amplify/auth": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-6.20.0.tgz",
+      "integrity": "sha512-y58KFRvmq7PoAboeiubU0qschyzcvis6erP+K3rsMBImjbwGLJGfDWYikdpw//JLw7L7NZzqt+mvtrZW9ITqeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.5.0"
+      },
+      "peerDependencies": {
+        "@aws-amplify/core": "^6.16.2",
+        "@aws-amplify/react-native": "^1.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@aws-amplify/react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-amplify/core": {
+      "version": "6.16.4",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.16.4.tgz",
+      "integrity": "sha512-RjJABL3lVByNcqeCeBuGWecfCtRS0paFdVyQ0nbA6XSJNYaoHT5J57WyGY8cUWmaKx2YNY0poFtuKaGXfRxjKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/util-hex-encoding": "2.0.0",
+        "@types/uuid": "^9.0.0",
+        "js-cookie": "^3.0.7",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.0",
+        "uuid": "^11.1.1"
+      }
+    },
+    "node_modules/@aws-amplify/data-schema": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema/-/data-schema-1.26.0.tgz",
+      "integrity": "sha512-k8RDc5klcJU2etz1JP3aAebAdzoxK7oCHNyqENGMpEirYtupP9+BYRfkmMq+aWGNaSw28qyjI55UXDy50O/nUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/data-schema-types": "*",
+        "@smithy/util-base64": "^3.0.0",
+        "@types/aws-lambda": "^8.10.134",
+        "@types/json-schema": "^7.0.15",
+        "rxjs": "^7.8.1"
+      }
+    },
+    "node_modules/@aws-amplify/data-schema-types": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema-types/-/data-schema-types-1.2.1.tgz",
+      "integrity": "sha512-SuYVcy9Hg8Ox9P0QCXEPwqHxX5zVPgVo2YvNBOm5TpkZr4UK6ir3USame7dELZsk5/9f6KoP70QAYhTvp/j1Og==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "graphql": "15.8.0",
+        "rxjs": "^7.8.1"
+      }
+    },
+    "node_modules/@aws-amplify/datastore": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.1.8.tgz",
+      "integrity": "sha512-kw4UbuOocRWFdOMrAdcWZqVshpBbdudZ1J4Qok6Qm0mp1d+kpFiDkM833nUvNzxxOPrxhrQUQjtj6nMBN/XK8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/api": "6.3.27",
+        "@aws-amplify/api-graphql": "4.8.8",
+        "buffer": "4.9.2",
+        "idb": "5.0.6",
+        "immer": "9.0.6",
+        "rxjs": "^7.8.1",
+        "ulid": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@aws-amplify/core": "^6.16.2"
+      }
+    },
+    "node_modules/@aws-amplify/notifications": {
+      "version": "2.0.94",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.0.94.tgz",
+      "integrity": "sha512-SFROWgXVWRoaO4vKXoQV/rDIS3gb7+LQT2W6HSpLsuVuNgHjvR1fUnOeGiZq0x3FhSJnHi9nlqZLtgQZ1aUYkQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "lodash": "^4.18.1",
+        "tslib": "^2.5.0"
+      },
+      "peerDependencies": {
+        "@aws-amplify/core": "^6.16.2"
+      }
+    },
+    "node_modules/@aws-amplify/storage": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-6.16.0.tgz",
+      "integrity": "sha512-f7xbVtvBXSuly2gUY3c0v/51Bm1UX708YtaKv1D2Hxmss29AdBc6MgTdKU/UmWRxfbheL3Ffr0Kdx4NQM9Ffbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/md5-js": "2.0.7",
+        "buffer": "4.9.2",
+        "crc-32": "1.2.2",
+        "fast-xml-parser": "^5.7.2",
+        "tslib": "^2.5.0"
+      },
+      "peerDependencies": {
+        "@aws-amplify/core": "^6.16.2"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-firehose": {
+      "version": "3.1073.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-firehose/-/client-firehose-3.1073.0.tgz",
+      "integrity": "sha512-mLaN92Jeqp3lHBnkaG1UgTxxQBODQ/C+njHKZZUasdav7di4R1Er7iVBOKheeVFZM66ZnZSEXzQxrL2MBPODlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/credential-provider-node": "^3.972.57",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-firehose/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kinesis": {
+      "version": "3.1073.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kinesis/-/client-kinesis-3.1073.0.tgz",
+      "integrity": "sha512-wqyICoxkNL9B3WQW3uk21836liP/zGYwjkJR5B/TE1xtt2QJ0+asBWbFfTyCA+eXE+59Ls6RuEVXuTak7fDepw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/credential-provider-node": "^3.972.57",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kinesis/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-personalize-events": {
+      "version": "3.1073.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-personalize-events/-/client-personalize-events-3.1073.0.tgz",
+      "integrity": "sha512-keMlZWu0Zr0+GasrZWm274PYIiF6EMBZ4hGNga5Ih6U5O+p3yMLbCNd6uPgTEaFSiIaiHs88wGajQXMV+MjCmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/credential-provider-node": "^3.972.57",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-personalize-events/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.22.tgz",
+      "integrity": "sha512-YofH63shc6YRdXjz80BJkpJW+Bkn0Cuu2dn4Rv7s9G2Idt58tgtzQEWxrR2xVljlVfIBeUjPuULnSVYLke3sUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@aws-sdk/xml-builder": "^3.972.30",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.48.tgz",
+      "integrity": "sha512-h6FEC95fbexUd6zxm4PdgS82bTcI2PRtUb2ZwMipb/Xr8bPwtf0G8rBo2jp7NA24Mbx2JA8/WingiYpA9RCCyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.50",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.50.tgz",
+      "integrity": "sha512-lJO3OLpjvz5m/RSBQmsG/CEUGsvCy5ruxKwPQaOCqxqCMuyYT2BZwQUTDZVVwqQ9LrZKuK24JSa6r31hL/tvkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.55.tgz",
+      "integrity": "sha512-TBoF4buBGYhXjdZAryayY2TrkQj2B2KfE/msG4V53XCt+w0EhEwM2JRjx8p2grJ2C6gtH5++SAwEvGMRdi0yyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/credential-provider-env": "^3.972.48",
+        "@aws-sdk/credential-provider-http": "^3.972.50",
+        "@aws-sdk/credential-provider-login": "^3.972.54",
+        "@aws-sdk/credential-provider-process": "^3.972.48",
+        "@aws-sdk/credential-provider-sso": "^3.972.54",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.54",
+        "@aws-sdk/nested-clients": "^3.997.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.54.tgz",
+      "integrity": "sha512-hBWI3wZTdTGiuMfmPts6AWbAjFfRniOQnqx68tc2cQvRKWawFbN9wkLOVPWM1FAOyowZU73mC6Fi+rHSHNyLFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/nested-clients": "^3.997.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.57.tgz",
+      "integrity": "sha512-u6dClpzNdWf1HGWz4wwhdXi1wiOofCLniM9S4BQQGlLAN9TW7VB+ld5V533GdKrYMaFeBGFqKnj0JCYvynLqwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.48",
+        "@aws-sdk/credential-provider-http": "^3.972.50",
+        "@aws-sdk/credential-provider-ini": "^3.972.55",
+        "@aws-sdk/credential-provider-process": "^3.972.48",
+        "@aws-sdk/credential-provider-sso": "^3.972.54",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.54",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.48.tgz",
+      "integrity": "sha512-w6VZwojPt12WnEkAUy6Nu4K6sWCbBmR7QX390b0nE6vRvkXbrYr9Lq9VySGkfjiMjpUA87op+J4EgvRmtWIDoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.54.tgz",
+      "integrity": "sha512-23uZpIpF2SIFDCa1fcWa202tK4gGeyvX6GIIAjiB8WBsvsVRBMnJ/7dCxHzxf7eZT7GToJg837LDIBnZsl/VUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/nested-clients": "^3.997.22",
+        "@aws-sdk/token-providers": "3.1071.0",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.54.tgz",
+      "integrity": "sha512-0Iv5QttS6wcATlodYKgvQj6B9Db51rx7NU9fqu0PoLeS4BIgdYMc/QK4smwLwpm5RFrs02V/eLyEFp3FklvlNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/nested-clients": "^3.997.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.22.tgz",
+      "integrity": "sha512-4IwtcYSxEIVw5hcp8ogq0CMbFNZFw7jJUetpfFUhFFeqsa1K8j2Ihg2hnxLyOp3stMZnXda6VzOmPi1AFZQXcg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
+      "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1071.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1071.0.tgz",
+      "integrity": "sha512-4LDW2Qob6LoLFuqYSYZq2AyTE9koSE9+i+n5UZcm10GpmQOK0zRD9L4uYlzItiTKksIWgC/qMFChAi3RvKYtMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/nested-clients": "^3.997.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
+      "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
+      "integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.30.tgz",
+      "integrity": "sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder/node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
@@ -453,6 +1297,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -508,6 +1362,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@cortex/encryption": {
       "resolved": "packages/encryption",
       "link": true
@@ -515,6 +1382,146 @@
     "node_modules/@cortex/web": {
       "resolved": "packages/web",
       "link": true
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.8.tgz",
+      "integrity": "sha512-3chWb7PRLijpJpPIKkDxdu6IBeO5MrFACND57On0j8OPpc0wZibcGc3xAHrSEbOx/KDRyMHoIxGn0w1PhXMYHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -548,6 +1555,24 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@fast-check/jest": {
@@ -1062,6 +2087,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.132.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
@@ -1427,12 +2464,406 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@smithy/core": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.25.1.tgz",
+      "integrity": "sha512-zpDbpXBCBsxfLtG2GEUyfgvHvSFrw5CwDZSNzL0v52gx/c3oPlPbm+7W7num8xs6vyiUBn+bvYPHcQDOXZynCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.1.tgz",
+      "integrity": "sha512-TSAF5NHgxEsllbErYWbK8aLnl5L601NGc5VYJlSPsKnf3YlkhdoBN+geGcaU00oiw2OK3QO5LA3QNXiiWhCidQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.1.tgz",
+      "integrity": "sha512-96JrD1q71anokymx9Iblb+zKmNQYNstlV/25A9ZYIJ2A0rp1r7/GZAIm0bDWSmVvz3DpNOCZuabzsiL+w0UHhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.0.7.tgz",
+      "integrity": "sha512-2i2BpXF9pI5D1xekqUsgQ/ohv5+H//G9FlawJrkOJskV18PgJ8LiNbLiskMeYt07yAsSTZR7qtlcAaa/GQLWww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.3.1",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/md5-js/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.1.tgz",
+      "integrity": "sha512-emtXvoky671puri18ETf64AFIQUGIEA093F2drXpBgB0OGnBLjcwNR3CA2mYu62IAqNsS56xa5lnTxAgPq7cjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.1.tgz",
+      "integrity": "sha512-X9rVls3En0z3NtrmguTmpRM0/NqtWUxBjal6fcAkwtsub+gOdLZ6kD+V7xhUgFMGdG14bHbZ7M5QjaRI1+DatQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
+      "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
+      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
+      "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
@@ -1444,6 +2875,19 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.162",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.162.tgz",
+      "integrity": "sha512-Fn658grtLOci1oxi1391vvDWJRKNGWRSqfxRkmN/Iy3c0tQH1USMKEXcPYHLvope+ZgTFocx9FRQJx1muBL6qw==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1553,6 +2997,12 @@
         "pretty-format": "^30.0.0"
       }
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.12.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
@@ -1588,6 +3038,12 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -2168,6 +3624,18 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/argon2id": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/argon2id/-/argon2id-1.0.1.tgz",
@@ -2184,6 +3652,16 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2192,6 +3670,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/aws-amplify": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.18.0.tgz",
+      "integrity": "sha512-a+dRKC+OBI94BBGfKVLK7e9hAqbG1mfkpRYDXh45HUs1CUwxDOBjzglXOfOvnzL0zL+mUfbvYpmYzsumGflk0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/analytics": "7.0.94",
+        "@aws-amplify/api": "6.3.27",
+        "@aws-amplify/auth": "6.20.0",
+        "@aws-amplify/core": "6.16.4",
+        "@aws-amplify/datastore": "5.1.8",
+        "@aws-amplify/notifications": "2.0.94",
+        "@aws-amplify/storage": "6.16.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/babel-jest": {
@@ -2300,6 +3794,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.33",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz",
@@ -2312,6 +3826,22 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "2.1.1",
@@ -2378,6 +3908,17 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "node_modules/buffer-from": {
@@ -2618,6 +4159,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2633,12 +4199,47 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2657,6 +4258,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.7.2",
@@ -2683,6 +4291,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2702,6 +4320,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -2736,6 +4361,19 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
@@ -2897,6 +4535,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
+      "integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.2.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^1.0.1",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -3050,6 +4727,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/graphql": {
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/handlebars": {
       "version": "4.7.9",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
@@ -3082,6 +4768,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -3097,6 +4796,42 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/idb": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-5.0.6.tgz",
+      "integrity": "sha512-/PFvOWPzRcEPmlDt5jEvzVZVs0wyd/EvGvkDIcbBpGuMMLQKrTPG0TxvE2UJtgZtCQCmOtM2QD7yQJBVEjKGOw==",
+      "license": "ISC"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/immer": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
+      "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-local": {
@@ -3127,6 +4862,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -3175,6 +4920,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -3187,6 +4939,24 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-unsafe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
+      "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3905,6 +5675,12 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/js-cookie": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3924,6 +5700,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -4262,6 +6089,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -4277,6 +6110,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -4335,6 +6178,13 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -4350,6 +6200,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -4602,6 +6462,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4610,6 +6483,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-is-absolute": {
@@ -4764,6 +6652,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
@@ -4802,6 +6700,13 @@
         "react": "^19.2.6"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/react-is-18": {
       "name": "react-is",
       "version": "18.3.1",
@@ -4818,10 +6723,72 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-router": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.0.tgz",
+      "integrity": "sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.0.tgz",
+      "integrity": "sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4885,6 +6852,28 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -4900,6 +6889,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -5180,6 +7175,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -5191,6 +7199,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
       }
     },
     "node_modules/supports-color": {
@@ -5205,6 +7228,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/synckit": {
       "version": "0.11.13",
@@ -5327,12 +7357,58 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.3.tgz",
+      "integrity": "sha512-A3BDQBeeukYPzB4QdQ1DtdlUmp4x2OCH8n5UVhEWbyANxNep8GavottKzd1xYKFJKjUgMyPT7EzOfnBO55s8Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.3"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.3.tgz",
+      "integrity": "sha512-27ep5H9PzdBrNd5OFM/j3WCU8F3kPwM9D0BOaOf7uYfxMJfyr0K5Tjj69Gri+sZlh2WXd5buIm47NuPF29CDiw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/ts-jest": {
       "version": "29.4.11",
@@ -5417,9 +7493,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -5470,6 +7544,25 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/ulid": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.4.0.tgz",
+      "integrity": "sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==",
+      "license": "MIT",
+      "bin": {
+        "ulid": "bin/cli.js"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -5546,6 +7639,19 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {
@@ -5731,6 +7837,19 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -5739,6 +7858,41 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -5897,6 +8051,38 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -6025,13 +8211,20 @@
       "version": "1.0.0",
       "dependencies": {
         "@cortex/encryption": "*",
+        "aws-amplify": "^6.18.0",
         "react": "^19.2.3",
-        "react-dom": "^19.2.3"
+        "react-dom": "^19.2.3",
+        "react-router-dom": "^7.18.0"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.2.3",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.0",
+        "jsdom": "^29.1.1",
         "typescript": "~5.9.0",
         "vite": "^8.0.0",
         "vitest": "^4.0.18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3636,12 +3636,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/argon2id": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/argon2id/-/argon2id-1.0.1.tgz",
-      "integrity": "sha512-rsiD3lX+0L0CsiZARp3bf9EGxprtuWAT7PpiJd+Fk53URV0/USOQkBIP1dLTV8t6aui0ECbymQ9W9YCcTd6XgA==",
-      "license": "MIT"
-    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -4767,6 +4761,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/hash-wasm": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.12.0.tgz",
+      "integrity": "sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ==",
+      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
@@ -8195,7 +8195,7 @@
         "@noble/ciphers": "^2.1.1",
         "@noble/hashes": "^2.0.1",
         "@scure/bip39": "^2.0.1",
-        "argon2id": "^1.0.1"
+        "hash-wasm": "^4.12.0"
       },
       "devDependencies": {
         "@fast-check/jest": "^2.1.1",

--- a/packages/encryption/package.json
+++ b/packages/encryption/package.json
@@ -23,7 +23,7 @@
     "@noble/ciphers": "^2.1.1",
     "@noble/hashes": "^2.0.1",
     "@scure/bip39": "^2.0.1",
-    "argon2id": "^1.0.1"
+    "hash-wasm": "^4.12.0"
   },
   "devDependencies": {
     "@fast-check/jest": "^2.1.1",

--- a/packages/encryption/src/lib/encryption.ts
+++ b/packages/encryption/src/lib/encryption.ts
@@ -9,9 +9,9 @@
  * Requirements: 1.1, 2.1, 9.1, 11.2, 11.4
  */
 
-import { chacha20poly1305 } from '@noble/ciphers/chacha';
-import { hmac } from '@noble/hashes/hmac';
-import { sha256 } from '@noble/hashes/sha2';
+import { chacha20poly1305 } from '@noble/ciphers/chacha.js';
+import { hmac } from '@noble/hashes/hmac.js';
+import { sha256 } from '@noble/hashes/sha2.js';
 
 // Use Web Crypto API for random bytes generation
 const getRandomBytes = async (size: number): Promise<Uint8Array> => {

--- a/packages/encryption/src/lib/envelope-encryption.ts
+++ b/packages/encryption/src/lib/envelope-encryption.ts
@@ -13,9 +13,9 @@
  * Requirements: 28.1–28.5, 29.2, 29.3
  */
 
-import { chacha20poly1305 } from '@noble/ciphers/chacha';
-import { hmac } from '@noble/hashes/hmac';
-import { sha256 } from '@noble/hashes/sha2';
+import { chacha20poly1305 } from '@noble/ciphers/chacha.js';
+import { hmac } from '@noble/hashes/hmac.js';
+import { sha256 } from '@noble/hashes/sha2.js';
 
 const WRAPPED_DEK_SIZE = 65;
 const WRAPPED_DEK_WITH_HMAC_SIZE = 97;

--- a/packages/encryption/src/lib/key-management.ts
+++ b/packages/encryption/src/lib/key-management.ts
@@ -5,8 +5,8 @@
  * key derivation for multiple encryption keys.
  */
 
-import { hkdf } from '@noble/hashes/hkdf';
-import { sha256 } from '@noble/hashes/sha2';
+import { hkdf } from '@noble/hashes/hkdf.js';
+import { sha256 } from '@noble/hashes/sha2.js';
 import { mnemonicToEntropy, entropyToMnemonic, validateMnemonic } from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english.js';
 

--- a/packages/encryption/src/lib/key-management.ts
+++ b/packages/encryption/src/lib/key-management.ts
@@ -1,133 +1,40 @@
 /**
  * Key Management Module
- * 
+ *
  * Implements vault master key derivation using Argon2id and HKDF-based
  * key derivation for multiple encryption keys.
  */
 
 import { hkdf } from '@noble/hashes/hkdf.js';
 import { sha256 } from '@noble/hashes/sha2.js';
+import { argon2id } from 'hash-wasm';
 import { mnemonicToEntropy, entropyToMnemonic, validateMnemonic } from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english.js';
 
-// Dynamic import for argon2id to handle both browser and Node.js environments
-let loadArgon2idWasm: (() => Promise<(params: {
-  password: Uint8Array;
-  salt: Uint8Array;
-  parallelism: number;
-  passes: number;
-  memorySize: number;
-  tagLength: number;
-}) => Uint8Array>) | null = null;
-
-// Initialize the loader based on environment
-async function initArgon2idLoader() {
-  if (loadArgon2idWasm) return loadArgon2idWasm;
-  
-  // Check if we're in Node.js environment
-  if (typeof process !== 'undefined' && process.versions && process.versions.node) {
-    // Node.js environment - use fs to load WASM files
-    try {
-      const fs = await import('fs');
-      const path = await import('path');
-      const { fileURLToPath } = await import('url');
-      const setupWasm = (await import('argon2id/lib/setup.js')).default;
-      
-      // Dynamically resolve argon2id package location using import.meta.resolve()
-      // This works in all monorepo configurations (npm workspaces, yarn PnP, pnpm)
-      // by letting Node.js resolve the package path instead of assuming a structure
-      let argon2idPath: string;
-      
-      try {
-        // Try import.meta.resolve() first (Node.js 20.6+)
-        const argon2idPackageUrl = import.meta.resolve('argon2id');
-        const argon2idPackagePath = fileURLToPath(argon2idPackageUrl);
-        argon2idPath = path.dirname(argon2idPackagePath);
-      } catch (resolveError) {
-        // Fallback: Use require.resolve if import.meta.resolve is not available
-        // This handles older Node.js versions and different module systems
-        try {
-          const argon2idMainPath = require.resolve('argon2id');
-          argon2idPath = path.dirname(argon2idMainPath);
-        } catch (requireError) {
-          throw new Error(
-            'Failed to resolve argon2id package location. ' +
-            'Ensure argon2id is installed and accessible. ' +
-            `import.meta.resolve error: ${resolveError instanceof Error ? resolveError.message : 'unknown'}; ` +
-            `require.resolve error: ${requireError instanceof Error ? requireError.message : 'unknown'}`
-          );
-        }
-      }
-      
-      const simdPath = path.join(argon2idPath, 'dist/simd.wasm');
-      const nonSimdPath = path.join(argon2idPath, 'dist/no-simd.wasm');
-      
-      loadArgon2idWasm = () => setupWasm(
-        (importObject: WebAssembly.Imports) => WebAssembly.instantiate(fs.readFileSync(simdPath), importObject),
-        (importObject: WebAssembly.Imports) => WebAssembly.instantiate(fs.readFileSync(nonSimdPath), importObject)
-      );
-    } catch (error) {
-      throw new Error(`Failed to initialize Argon2id for Node.js: ${error instanceof Error ? error.message : 'Unknown error'}`);
-    }
-  } else {
-    // Browser environment - use default loader
-    const defaultLoader = (await import('argon2id')).default;
-    loadArgon2idWasm = defaultLoader;
-  }
-  
-  return loadArgon2idWasm;
-}
-
 /**
- * Argon2id parameters for vault master key derivation
- * - Memory: 64MB (65536 KB)
- * - Iterations: 3
+ * Argon2id parameters for vault master key derivation (RFC 9106).
+ * - Memory: 64 MiB (65536 KiB)
+ * - Iterations (time cost): 3
  * - Parallelism: 4
- * - Hash length: 32 bytes (256 bits)
+ * - Output: 32 bytes (256 bits)
+ *
+ * Uses hash-wasm's WASM Argon2id (WASM inlined as base64 → bundles for the browser
+ * with no plugins and no Node fs). Output is identical to any conformant Argon2id
+ * implementation for the same parameters.
  */
-const ARGON2_PARAMS = {
-  memorySize: 65536, // 64MB in KB
-  passes: 3,
-  parallelism: 4,
-  tagLength: 32, // 256 bits output
-};
-
-/**
- * Cached Argon2id WASM instance
- * Initialized on first use to avoid repeated WASM loading
- */
-let argon2idInstance: ((params: {
-  password: Uint8Array;
-  salt: Uint8Array;
-  parallelism: number;
-  passes: number;
-  memorySize: number;
-  tagLength: number;
-}) => Uint8Array) | null = null;
-
-/**
- * Loads and caches the Argon2id WASM instance
- * @returns Promise<Argon2id function>
- */
-async function getArgon2id() {
-  if (!argon2idInstance) {
-    const loader = await initArgon2idLoader();
-    argon2idInstance = await loader();
-  }
-  return argon2idInstance;
-}
+const ARGON2_PARAMS = { parallelism: 4, iterations: 3, memorySize: 65536, hashLength: 32 } as const;
 
 /**
  * HKDF fixed salts for defense-in-depth domain separation
- * 
+ *
  * These salts provide an additional layer of cryptographic separation beyond
  * the context strings (info parameter). While RFC 5869 allows optional salts,
  * using fixed versioned salts provides:
- * 
+ *
  * 1. Defense-in-depth: Two independent layers of domain separation
  * 2. Future-proofing: Version suffix allows salt rotation if needed
  * 3. Best practice: Conservative cryptographic approach
- * 
+ *
  * Design decision: Fixed salts (not random) because:
  * - Deterministic key derivation is required (same master key → same derived keys)
  * - Salts don't need to be secret, just unique per key type
@@ -148,7 +55,7 @@ const HKDF_SALTS = {
 
 /**
  * HKDF context strings for deriving different encryption keys
- * 
+ *
  * These provide the primary domain separation (via the info parameter).
  * Combined with HKDF_SALTS, this provides two independent layers of separation.
  */
@@ -172,14 +79,14 @@ const HKDF_CONTEXTS = {
 
 /**
  * Derives a 256-bit vault master key from a vault password and salt using Argon2id.
- * 
+ *
  * This function uses memory-hard key derivation to protect against brute-force attacks.
  * The same password and salt will always produce the same master key (deterministic).
- * 
+ *
  * @param password - The vault password (string)
  * @param salt - The vault salt (Uint8Array, 16 bytes minimum)
  * @returns Promise<Uint8Array> - The 256-bit (32-byte) vault master key
- * 
+ *
  * @example
  * const password = 'my-secure-vault-password';
  * const salt = crypto.getRandomValues(new Uint8Array(16));
@@ -198,20 +105,9 @@ export async function deriveVaultMasterKey(
   }
 
   try {
-    // Load Argon2id WASM instance (cached after first load)
-    const argon2id = await getArgon2id();
-    
-    // Convert password string to Uint8Array
-    const passwordBytes = new TextEncoder().encode(password);
-    
-    // Derive vault master key using Argon2id
-    const hash = argon2id({
-      password: passwordBytes,
-      salt,
-      ...ARGON2_PARAMS,
-    });
-
-    return hash;
+    // Argon2id (RFC 9106) via hash-wasm. hash-wasm UTF-8-encodes a string password,
+    // matching the previous TextEncoder().encode(password) behavior byte-for-byte.
+    return await argon2id({ password, salt, ...ARGON2_PARAMS, outputType: 'binary' });
   } catch (error) {
     throw new Error(`Failed to derive vault master key: ${error instanceof Error ? error.message : 'Unknown error'}`);
   }
@@ -235,14 +131,14 @@ export interface DerivedKeys {
 
 /**
  * Derives multiple encryption keys from the vault master key using HKDF-SHA256.
- * 
+ *
  * Each key is derived with both a unique salt and context string for defense-in-depth
  * domain separation. This provides two independent layers of cryptographic separation.
  * All derived keys are 256 bits (32 bytes) for use with ChaCha20-Poly1305.
- * 
+ *
  * @param vaultMasterKey - The 256-bit vault master key (from deriveVaultMasterKey)
  * @returns DerivedKeys - Object containing all derived encryption keys
- * 
+ *
  * @example
  * const masterKey = await deriveVaultMasterKey(password, salt);
  * const keys = deriveKeys(masterKey);
@@ -329,18 +225,18 @@ export function deriveKeys(vaultMasterKey: Uint8Array): DerivedKeys {
 
 /**
  * Generates a BIP39 mnemonic recovery key from the vault master key.
- * 
+ *
  * The recovery key is a 24-word mnemonic phrase that encodes the FULL 256-bit
  * vault master key. This enables complete offline vault recovery without requiring
  * the vault salt from the server. The user can recover their vault with ONLY
  * this 24-word phrase.
- * 
+ *
  * SECURITY: This should be displayed to the user ONCE during vault creation with
  * instructions to store it securely offline (paper backup, password manager, etc.).
- * 
+ *
  * @param vaultMasterKey - The 256-bit vault master key
  * @returns string - A 24-word BIP39 mnemonic phrase
- * 
+ *
  * @example
  * const masterKey = await deriveVaultMasterKey(password, salt);
  * const recoveryKey = generateRecoveryKey(masterKey);
@@ -364,24 +260,24 @@ export function generateRecoveryKey(vaultMasterKey: Uint8Array): string {
 
 /**
  * Validates a recovery key and recovers the full vault master key from it.
- * 
+ *
  * This function is used during vault password reset. The user provides their
  * recovery key (24-word mnemonic), and this function validates it and returns
  * the complete 256-bit vault master key.
- * 
+ *
  * SECURITY: This enables complete offline vault recovery. The user does NOT need
  * the vault salt from the server - the 24-word phrase contains everything needed
  * to recover full vault access.
- * 
+ *
  * After recovery, the user can:
  * 1. Use the recovered master key directly to decrypt their vault
  * 2. Set a new vault password and derive a new vault salt
  * 3. Re-encrypt the vault with the new password (optional)
- * 
+ *
  * @param recoveryKey - The 24-word BIP39 mnemonic phrase
  * @returns Uint8Array - The complete 256-bit vault master key (32 bytes)
  * @throws Error if the recovery key is invalid
- * 
+ *
  * @example
  * const recoveryKey = 'word1 word2 word3 ... word24';
  * const recoveredMasterKey = validateRecoveryKey(recoveryKey);
@@ -401,11 +297,11 @@ export function validateRecoveryKey(recoveryKey: string): Uint8Array {
   try {
     // Convert mnemonic back to full 256-bit master key
     const masterKey = mnemonicToEntropy(recoveryKey, wordlist);
-    
+
     if (masterKey.length !== 32) {
       throw new Error('Recovery key must be 24 words (256 bits)');
     }
-    
+
     return masterKey;
   } catch (error) {
     throw new Error(`Failed to validate recovery key: ${error instanceof Error ? error.message : 'Unknown error'}`);

--- a/packages/encryption/src/lib/password-validation.ts
+++ b/packages/encryption/src/lib/password-validation.ts
@@ -5,7 +5,7 @@
  * Have I Been Pwned API with k-anonymity model.
  */
 
-import { sha1 } from '@noble/hashes/legacy';
+import { sha1 } from '@noble/hashes/legacy.js';
 
 /**
  * Password validation result

--- a/packages/encryption/src/lib/share-encryption.ts
+++ b/packages/encryption/src/lib/share-encryption.ts
@@ -17,9 +17,9 @@
  *   [version(1)][salt(16)][wrappedDek(65)][hmac(32)] = 114 bytes -> ~152 chars base64url
  */
 
-import { hkdf } from '@noble/hashes/hkdf';
-import { sha256 } from '@noble/hashes/sha2';
-import { hmac } from '@noble/hashes/hmac';
+import { hkdf } from '@noble/hashes/hkdf.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { hmac } from '@noble/hashes/hmac.js';
 
 // Dynamic import for argon2id to handle both browser and Node.js environments
 let loadArgon2idWasm: (() => Promise<(params: {

--- a/packages/encryption/src/lib/share-encryption.ts
+++ b/packages/encryption/src/lib/share-encryption.ts
@@ -20,98 +20,15 @@
 import { hkdf } from '@noble/hashes/hkdf.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { hmac } from '@noble/hashes/hmac.js';
-
-// Dynamic import for argon2id to handle both browser and Node.js environments
-let loadArgon2idWasm: (() => Promise<(params: {
-  password: Uint8Array;
-  salt: Uint8Array;
-  parallelism: number;
-  passes: number;
-  memorySize: number;
-  tagLength: number;
-}) => Uint8Array>) | null = null;
-
-// Initialize the loader based on environment
-async function initArgon2idLoader() {
-  if (loadArgon2idWasm) return loadArgon2idWasm;
-
-  // Check if we're in Node.js environment
-  if (typeof process !== 'undefined' && process.versions && process.versions.node) {
-    try {
-      const fs = await import('fs');
-      const path = await import('path');
-      const { fileURLToPath } = await import('url');
-      const setupWasm = (await import('argon2id/lib/setup.js')).default;
-
-      let argon2idPath: string;
-
-      try {
-        const argon2idPackageUrl = import.meta.resolve('argon2id');
-        const argon2idPackagePath = fileURLToPath(argon2idPackageUrl);
-        argon2idPath = path.dirname(argon2idPackagePath);
-      } catch (resolveError) {
-        try {
-          const argon2idMainPath = require.resolve('argon2id');
-          argon2idPath = path.dirname(argon2idMainPath);
-        } catch (requireError) {
-          throw new Error(
-            'Failed to resolve argon2id package location. ' +
-            'Ensure argon2id is installed and accessible. ' +
-            `import.meta.resolve error: ${resolveError instanceof Error ? resolveError.message : 'unknown'}; ` +
-            `require.resolve error: ${requireError instanceof Error ? requireError.message : 'unknown'}`
-          );
-        }
-      }
-
-      const simdPath = path.join(argon2idPath, 'dist/simd.wasm');
-      const nonSimdPath = path.join(argon2idPath, 'dist/no-simd.wasm');
-
-      loadArgon2idWasm = () => setupWasm(
-        (importObject: WebAssembly.Imports) => WebAssembly.instantiate(fs.readFileSync(simdPath), importObject),
-        (importObject: WebAssembly.Imports) => WebAssembly.instantiate(fs.readFileSync(nonSimdPath), importObject)
-      );
-    } catch (error) {
-      throw new Error(`Failed to initialize Argon2id for Node.js: ${error instanceof Error ? error.message : 'Unknown error'}`);
-    }
-  } else {
-    // Browser environment - use default loader
-    const defaultLoader = (await import('argon2id')).default;
-    loadArgon2idWasm = defaultLoader;
-  }
-
-  return loadArgon2idWasm;
-}
+import { argon2id } from 'hash-wasm';
 
 /**
- * Argon2id parameters for share key derivation
- * Matches vault key derivation: 64MB memory, 3 iterations, 4 parallelism
+ * Argon2id parameters for share key derivation (RFC 9106).
+ * Matches vault key derivation: 64 MiB memory, 3 iterations, 4 parallelism, 32-byte output.
+ *
+ * Uses hash-wasm's WASM Argon2id (WASM inlined → browser-bundleable, no plugins/fs).
  */
-const ARGON2_PARAMS = {
-  memorySize: 65536, // 64MB in KB
-  passes: 3,
-  parallelism: 4,
-  tagLength: 32, // 256 bits output
-};
-
-/**
- * Cached Argon2id WASM instance
- */
-let argon2idInstance: ((params: {
-  password: Uint8Array;
-  salt: Uint8Array;
-  parallelism: number;
-  passes: number;
-  memorySize: number;
-  tagLength: number;
-}) => Uint8Array) | null = null;
-
-async function getArgon2id() {
-  if (!argon2idInstance) {
-    const loader = await initArgon2idLoader();
-    argon2idInstance = await loader();
-  }
-  return argon2idInstance;
-}
+const ARGON2_PARAMS = { parallelism: 4, iterations: 3, memorySize: 65536, hashLength: 32 } as const;
 
 // --- HKDF salts and contexts for share key derivation ---
 
@@ -268,15 +185,8 @@ export async function deriveShareKeys(
   const keyLength = 32;
 
   try {
-    const argon2id = await getArgon2id();
-
-    const passwordBytes = new TextEncoder().encode(password);
-
-    const shareMasterKey = argon2id({
-      password: passwordBytes,
-      salt,
-      ...ARGON2_PARAMS,
-    });
+    // Argon2id (RFC 9106) via hash-wasm — WASM inlined, browser-bundleable.
+    const shareMasterKey = await argon2id({ password, salt, ...ARGON2_PARAMS, outputType: 'binary' });
 
     try {
       const encryptionKey = hkdf(

--- a/packages/encryption/src/lib/vault-salt-integrity.ts
+++ b/packages/encryption/src/lib/vault-salt-integrity.ts
@@ -12,8 +12,8 @@
  * Spec: .kiro/specs/cortex/tasks.md task 10.2, requirements 22.6-22.12.
  */
 
-import { hmac } from '@noble/hashes/hmac';
-import { sha256 } from '@noble/hashes/sha2';
+import { hmac } from '@noble/hashes/hmac.js';
+import { sha256 } from '@noble/hashes/sha2.js';
 import {
   storeSaltHmacRecord,
   retrieveSaltHmacRecord,

--- a/packages/encryption/tests/unit/key-management.test.ts
+++ b/packages/encryption/tests/unit/key-management.test.ts
@@ -115,6 +115,33 @@ describe('Key Management', () => {
     });
   });
 
+  describe('deriveVaultMasterKey', () => {
+    const KAT_SALT = new Uint8Array(16).fill(0x42);
+    // Argon2id(t=3, m=64MB, p=4, dkLen=32) over UTF-8 "correct horse battery staple 12".
+    // Standardized KDF → identical across implementations; pins the swap to @noble/hashes.
+    const KAT_HEX = '5c88eecd72d28909ed99588a8f9b9ca80d7a7f65429dcd450a0d832371bf43b3';
+
+    it('matches the Argon2id known-answer vector', async () => {
+      const mk = await deriveVaultMasterKey('correct horse battery staple 12', KAT_SALT);
+      expect(mk).toBeInstanceOf(Uint8Array);
+      expect(mk).toHaveLength(32);
+      expect(Buffer.from(mk).toString('hex')).toBe(KAT_HEX);
+    });
+
+    it('is deterministic for the same password and salt', async () => {
+      const a = await deriveVaultMasterKey('pw-123', KAT_SALT);
+      const b = await deriveVaultMasterKey('pw-123', KAT_SALT);
+      expect(Buffer.from(a).equals(Buffer.from(b))).toBe(true);
+    });
+
+    it('rejects an empty password and a too-short salt', async () => {
+      await expect(deriveVaultMasterKey('', KAT_SALT)).rejects.toThrow('Password cannot be empty');
+      await expect(deriveVaultMasterKey('pw', new Uint8Array(8))).rejects.toThrow(
+        'at least 16 bytes',
+      );
+    });
+  });
+
   describe('generateRecoveryKey and validateRecoveryKey', () => {
     it('should generate a valid BIP39 mnemonic', () => {
       const masterKey = createMockMasterKey();

--- a/packages/web/.env.example
+++ b/packages/web/.env.example
@@ -1,0 +1,4 @@
+VITE_USER_POOL_ID=us-east-1_xxxxxxxxx
+VITE_USER_POOL_CLIENT_ID=xxxxxxxxxxxxxxxxxxxxxxxxxx
+VITE_AWS_REGION=us-east-1
+VITE_API_BASE_URL=http://localhost:3000

--- a/packages/web/.env.example
+++ b/packages/web/.env.example
@@ -1,4 +1,3 @@
 VITE_USER_POOL_ID=us-east-1_xxxxxxxxx
 VITE_USER_POOL_CLIENT_ID=xxxxxxxxxxxxxxxxxxxxxxxxxx
-VITE_AWS_REGION=us-east-1
 VITE_API_BASE_URL=http://localhost:3000

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -13,13 +13,20 @@
   },
   "dependencies": {
     "@cortex/encryption": "*",
+    "aws-amplify": "^6.18.0",
     "react": "^19.2.3",
-    "react-dom": "^19.2.3"
+    "react-dom": "^19.2.3",
+    "react-router-dom": "^7.18.0"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.0",
+    "jsdom": "^29.1.1",
     "typescript": "~5.9.0",
     "vite": "^8.0.0",
     "vitest": "^4.0.18"

--- a/packages/web/src/App.test.tsx
+++ b/packages/web/src/App.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+const state = vi.hoisted(() => ({ status: 'signedOut' as string }));
+vi.mock('./auth/SessionContext', async (o) => ({
+  ...(await o<typeof import('./auth/SessionContext')>()),
+  SessionProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useSession: () => ({ status: state.status }),
+}));
+
+import App from './App';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('App routing', () => {
+  it('shows Login at /login when signed out', () => {
+    state.status = 'signedOut';
+    window.history.pushState({}, '', '/login');
+    render(<App />);
+    expect(screen.getByRole('heading', { name: /log in/i })).toBeInTheDocument();
+  });
+
+  it('shows the Dashboard at / when unlocked', () => {
+    state.status = 'unlocked';
+    window.history.pushState({}, '', '/');
+    render(<App />);
+    expect(screen.getByRole('heading', { name: /dashboard/i })).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,18 +1,53 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { SessionProvider } from './auth/SessionContext';
+import { RequireAuth, RequireVault } from './auth/guards';
+import Signup from './components/Signup';
+import VerifyEmail from './components/VerifyEmail';
+import Login from './components/Login';
+import VaultSetup from './components/VaultSetup';
+import VaultUnlock from './components/VaultUnlock';
+import Dashboard from './components/Dashboard';
 import { ShareAccess } from './components/ShareAccess';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
 
-function App() {
-  if (window.location.pathname.startsWith('/s')) {
-    return <ShareAccess apiBaseUrl={API_BASE_URL} />;
-  }
-
+export default function App() {
   return (
-    <div style={{ padding: '2rem' }}>
-      <h1>Cortex</h1>
-      <p>Zero-Knowledge Media Backup</p>
-    </div>
+    <SessionProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/s/*" element={<ShareAccess apiBaseUrl={API_BASE_URL} />} />
+          <Route path="/signup" element={<Signup />} />
+          <Route path="/verify" element={<VerifyEmail />} />
+          <Route path="/login" element={<Login />} />
+          <Route
+            path="/vault/setup"
+            element={
+              <RequireAuth>
+                <VaultSetup />
+              </RequireAuth>
+            }
+          />
+          <Route
+            path="/vault/unlock"
+            element={
+              <RequireAuth>
+                <VaultUnlock />
+              </RequireAuth>
+            }
+          />
+          <Route
+            path="/"
+            element={
+              <RequireAuth>
+                <RequireVault>
+                  <Dashboard />
+                </RequireVault>
+              </RequireAuth>
+            }
+          />
+        </Routes>
+      </BrowserRouter>
+    </SessionProvider>
   );
 }
-
-export default App;

--- a/packages/web/src/api/client.test.ts
+++ b/packages/web/src/api/client.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { bytesToBase64 } from '@cortex/encryption';
+
+vi.mock('aws-amplify/auth', () => ({
+  fetchAuthSession: vi.fn(async () => ({
+    tokens: { idToken: { toString: () => 'JWT123' } },
+  })),
+}));
+vi.mock('../config', () => ({
+  getConfig: () => ({
+    userPoolId: 'p',
+    userPoolClientId: 'c',
+    region: 'r',
+    apiBaseUrl: 'https://api',
+  }),
+}));
+
+import { createVault, getVaultSalt } from './client';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('api client', () => {
+  it('createVault POSTs with bearer token and decodes the salt', async () => {
+    const salt = new Uint8Array(16).fill(7);
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ vaultId: 'v1', vaultSalt: bytesToBase64(salt), createdAt: 1 }),
+          { status: 200 },
+        ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await createVault();
+
+    expect(result).toEqual({ vaultId: 'v1', vaultSalt: salt });
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api/v1/vaults');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer JWT123');
+  });
+
+  it('getVaultSalt GETs and decodes the salt', async () => {
+    const salt = new Uint8Array(16).fill(3);
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ vaultSalt: bytesToBase64(salt) }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await getVaultSalt('v9');
+
+    expect(result).toEqual(salt);
+    expect(fetchMock.mock.calls[0][0]).toBe('https://api/v1/vaults/v9/salt');
+  });
+
+  it('throws on non-2xx', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('nope', { status: 401 })));
+    await expect(getVaultSalt('v9')).rejects.toThrow('401');
+  });
+});

--- a/packages/web/src/api/client.test.ts
+++ b/packages/web/src/api/client.test.ts
@@ -36,7 +36,7 @@ describe('api client', () => {
     const result = await createVault();
 
     expect(result).toEqual({ vaultId: 'v1', vaultSalt: salt });
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
     expect(url).toBe('https://api/v1/vaults');
     expect(init.method).toBe('POST');
     expect((init.headers as Record<string, string>).Authorization).toBe('Bearer JWT123');
@@ -52,7 +52,9 @@ describe('api client', () => {
     const result = await getVaultSalt('v9');
 
     expect(result).toEqual(salt);
-    expect(fetchMock.mock.calls[0][0]).toBe('https://api/v1/vaults/v9/salt');
+    expect((fetchMock.mock.calls[0] as unknown as [string])[0]).toBe(
+      'https://api/v1/vaults/v9/salt',
+    );
   });
 
   it('throws on non-2xx', async () => {

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -1,0 +1,32 @@
+import { fetchAuthSession } from 'aws-amplify/auth';
+import { base64ToBytes } from '@cortex/encryption';
+import { getConfig } from '../config';
+
+export async function authHeader(): Promise<{ Authorization: string }> {
+  const session = await fetchAuthSession();
+  const jwt = session.tokens?.idToken?.toString();
+  if (!jwt) throw new Error('No Cognito session — sign in first');
+  return { Authorization: `Bearer ${jwt}` };
+}
+
+async function request(path: string, init: RequestInit = {}): Promise<any> {
+  const { apiBaseUrl } = getConfig();
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(await authHeader()),
+    ...(init.headers ?? {}),
+  };
+  const res = await fetch(`${apiBaseUrl}${path}`, { ...init, headers });
+  if (!res.ok) throw new Error(`API ${path} failed: ${res.status}`);
+  return res.json();
+}
+
+export async function createVault(): Promise<{ vaultId: string; vaultSalt: Uint8Array }> {
+  const body = await request('/v1/vaults', { method: 'POST', body: JSON.stringify({}) });
+  return { vaultId: body.vaultId, vaultSalt: base64ToBytes(body.vaultSalt) };
+}
+
+export async function getVaultSalt(vaultId: string): Promise<Uint8Array> {
+  const body = await request(`/v1/vaults/${encodeURIComponent(vaultId)}/salt`, { method: 'GET' });
+  return base64ToBytes(body.vaultSalt);
+}

--- a/packages/web/src/auth/SessionContext.auth.test.tsx
+++ b/packages/web/src/auth/SessionContext.auth.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// vi.hoisted so `amplify` is initialized before the hoisted vi.mock factory runs.
+const amplify = vi.hoisted(() => ({
+  signUp: vi.fn(async () => ({ isSignUpComplete: false })),
+  confirmSignUp: vi.fn(async () => ({ isSignUpComplete: true })),
+  signIn: vi.fn(async () => ({ isSignedIn: true })),
+  signOut: vi.fn(async () => {}),
+  getCurrentUser: vi.fn(async () => {
+    throw new Error('no user');
+  }),
+}));
+vi.mock('aws-amplify/auth', () => amplify);
+
+import { SessionProvider, useSession } from './SessionContext';
+
+function Probe() {
+  const s = useSession();
+  return (
+    <div>
+      <span data-testid="status">{s.status}</span>
+      <button onClick={() => s.signInAccount('a@b.com', 'pw')}>signin</button>
+      <button onClick={() => s.logout()}>logout</button>
+    </div>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+describe('SessionContext auth', () => {
+  it('starts signedOut when no current user', async () => {
+    render(
+      <SessionProvider>
+        <Probe />
+      </SessionProvider>,
+    );
+    expect(await screen.findByTestId('status')).toHaveTextContent('signedOut');
+  });
+
+  it('signInAccount → signedInVaultLocked, logout → signedOut', async () => {
+    render(
+      <SessionProvider>
+        <Probe />
+      </SessionProvider>,
+    );
+    await screen.findByText('signin');
+    await act(async () => {
+      await userEvent.click(screen.getByText('signin'));
+    });
+    expect(amplify.signIn).toHaveBeenCalledWith({ username: 'a@b.com', password: 'pw' });
+    expect(screen.getByTestId('status')).toHaveTextContent('signedInVaultLocked');
+    await act(async () => {
+      await userEvent.click(screen.getByText('logout'));
+    });
+    expect(screen.getByTestId('status')).toHaveTextContent('signedOut');
+  });
+});

--- a/packages/web/src/auth/SessionContext.tsx
+++ b/packages/web/src/auth/SessionContext.tsx
@@ -1,5 +1,16 @@
 import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from 'react';
 import { signUp, confirmSignUp, signIn, signOut, getCurrentUser } from 'aws-amplify/auth';
+import {
+  deriveVaultMasterKey,
+  deriveKeys,
+  generateRecoveryKey,
+  storeKeys,
+  clearKeys,
+} from '@cortex/encryption';
+import { createVault, getVaultSalt } from '../api/client';
+import { createVerifier, checkVerifier, saveVerifier, loadVerifier } from '../vault/verifier';
+
+const VAULT_ID_KEY = 'cortex_vault_id';
 
 export type SessionStatus = 'loading' | 'signedOut' | 'signedInVaultLocked' | 'unlocked';
 
@@ -39,16 +50,39 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const logout = useCallback(async () => {
+    const vaultId = localStorage.getItem(VAULT_ID_KEY);
+    if (vaultId) await clearKeys(vaultId);
     await signOut();
     setStatus('signedOut');
   }, []);
 
-  // Replaced in Task 5 — throw so they are never silently no-ops.
-  const setupVault = useCallback(async (_vaultPassword: string): Promise<string> => {
-    throw new Error('setupVault not implemented yet (Task 5)');
+  const setupVault = useCallback(async (vaultPassword: string): Promise<string> => {
+    const { vaultId, vaultSalt } = await createVault();
+    localStorage.setItem(VAULT_ID_KEY, vaultId);
+    const master = await deriveVaultMasterKey(vaultPassword, vaultSalt);
+    const keys = deriveKeys(master);
+    saveVerifier(vaultId, await createVerifier(keys.metadataEncryptionKey));
+    const recovery = generateRecoveryKey(master);
+    await storeKeys(vaultId, keys);
+    setStatus('unlocked');
+    return recovery;
   }, []);
-  const unlockVault = useCallback(async (_vaultPassword: string) => {
-    throw new Error('unlockVault not implemented yet (Task 5)');
+
+  const unlockVault = useCallback(async (vaultPassword: string): Promise<void> => {
+    const vaultId = localStorage.getItem(VAULT_ID_KEY);
+    if (!vaultId) throw new Error('No vault on this device — set one up first');
+    const salt = await getVaultSalt(vaultId);
+    const master = await deriveVaultMasterKey(vaultPassword, salt);
+    const keys = deriveKeys(master);
+    const verifier = loadVerifier(vaultId);
+    // Missing verifier is a hard failure: unlocking without it would silently accept a
+    // wrong password and store keys that decrypt nothing.
+    if (!verifier) throw new Error('Vault verifier missing on this device — re-run setup');
+    if (!checkVerifier(verifier, keys.metadataEncryptionKey)) {
+      throw new Error('Incorrect vault password');
+    }
+    await storeKeys(vaultId, keys);
+    setStatus('unlocked');
   }, []);
 
   const value: SessionValue = {

--- a/packages/web/src/auth/SessionContext.tsx
+++ b/packages/web/src/auth/SessionContext.tsx
@@ -1,0 +1,70 @@
+import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from 'react';
+import { signUp, confirmSignUp, signIn, signOut, getCurrentUser } from 'aws-amplify/auth';
+
+export type SessionStatus = 'loading' | 'signedOut' | 'signedInVaultLocked' | 'unlocked';
+
+export interface SessionValue {
+  status: SessionStatus;
+  signUpAccount(email: string, password: string): Promise<void>;
+  confirmAccount(email: string, code: string): Promise<void>;
+  signInAccount(email: string, password: string): Promise<void>;
+  logout(): Promise<void>;
+  // Implemented in Task 5:
+  setupVault(vaultPassword: string): Promise<string>; // returns the BIP39 recovery phrase
+  unlockVault(vaultPassword: string): Promise<void>;
+}
+
+const SessionContext = createContext<SessionValue | null>(null);
+
+export function SessionProvider({ children }: { children: ReactNode }) {
+  const [status, setStatus] = useState<SessionStatus>('loading');
+
+  useEffect(() => {
+    getCurrentUser()
+      .then(() => setStatus('signedInVaultLocked'))
+      .catch(() => setStatus('signedOut'));
+  }, []);
+
+  const signUpAccount = useCallback(async (email: string, password: string) => {
+    await signUp({ username: email, password, options: { userAttributes: { email } } });
+  }, []);
+
+  const confirmAccount = useCallback(async (email: string, code: string) => {
+    await confirmSignUp({ username: email, confirmationCode: code });
+  }, []);
+
+  const signInAccount = useCallback(async (email: string, password: string) => {
+    await signIn({ username: email, password });
+    setStatus('signedInVaultLocked');
+  }, []);
+
+  const logout = useCallback(async () => {
+    await signOut();
+    setStatus('signedOut');
+  }, []);
+
+  // Replaced in Task 5 — throw so they are never silently no-ops.
+  const setupVault = useCallback(async (_vaultPassword: string): Promise<string> => {
+    throw new Error('setupVault not implemented yet (Task 5)');
+  }, []);
+  const unlockVault = useCallback(async (_vaultPassword: string) => {
+    throw new Error('unlockVault not implemented yet (Task 5)');
+  }, []);
+
+  const value: SessionValue = {
+    status,
+    signUpAccount,
+    confirmAccount,
+    signInAccount,
+    logout,
+    setupVault,
+    unlockVault,
+  };
+  return <SessionContext.Provider value={value}>{children}</SessionContext.Provider>;
+}
+
+export function useSession(): SessionValue {
+  const ctx = useContext(SessionContext);
+  if (!ctx) throw new Error('useSession must be used within SessionProvider');
+  return ctx;
+}

--- a/packages/web/src/auth/SessionContext.vault.test.tsx
+++ b/packages/web/src/auth/SessionContext.vault.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { deriveKeys } from '@cortex/encryption';
+import { createVerifier, saveVerifier } from '../vault/verifier';
+
+// Hoisted so the vi.mock factories below can reference these without a TDZ error.
+const { SALT, MASTER, api } = vi.hoisted(() => ({
+  SALT: new Uint8Array(16).fill(9),
+  MASTER: new Uint8Array(32).fill(5),
+  api: { createVault: vi.fn(), getVaultSalt: vi.fn() },
+}));
+
+vi.mock('aws-amplify/auth', () => ({
+  signUp: vi.fn(),
+  confirmSignUp: vi.fn(),
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+  getCurrentUser: vi.fn(async () => ({ userId: 'u1' })), // already signed in
+}));
+
+vi.mock('../api/client', () => api);
+
+// Real verifier + real deriveKeys/encrypt/decrypt; mock only the slow Argon2id step.
+vi.mock('@cortex/encryption', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@cortex/encryption')>();
+  return {
+    ...actual,
+    deriveVaultMasterKey: vi.fn(async () => MASTER),
+    generateRecoveryKey: vi.fn(() => 'word '.repeat(24).trim()),
+    storeKeys: vi.fn(async () => {}),
+    clearKeys: vi.fn(async () => {}),
+  };
+});
+
+import { SessionProvider, useSession } from './SessionContext';
+
+function Probe() {
+  const s = useSession();
+  return (
+    <div>
+      <span data-testid="status">{s.status}</span>
+      <button onClick={() => s.setupVault('vaultpw').then((r) => (document.title = r))}>setup</button>
+      <button onClick={() => s.unlockVault('vaultpw').catch((e) => (document.title = e.message))}>
+        unlock
+      </button>
+    </div>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  document.title = '';
+});
+
+describe('SessionContext vault', () => {
+  it('setupVault creates a vault, stores keys, unlocks, returns recovery phrase', async () => {
+    api.createVault.mockResolvedValue({ vaultId: 'v1', vaultSalt: SALT });
+    render(
+      <SessionProvider>
+        <Probe />
+      </SessionProvider>,
+    );
+    await screen.findByText('setup');
+    await act(async () => {
+      screen.getByText('setup').click();
+    });
+    expect(api.createVault).toHaveBeenCalled();
+    expect(localStorage.getItem('cortex_vault_id')).toBe('v1');
+    expect(screen.getByTestId('status')).toHaveTextContent('unlocked');
+    expect(document.title.split(' ')).toHaveLength(24);
+  });
+
+  it('unlockVault with the correct password unlocks', async () => {
+    const keys = deriveKeys(MASTER);
+    localStorage.setItem('cortex_vault_id', 'v1');
+    saveVerifier('v1', await createVerifier(keys.metadataEncryptionKey));
+    api.getVaultSalt.mockResolvedValue(SALT);
+
+    render(
+      <SessionProvider>
+        <Probe />
+      </SessionProvider>,
+    );
+    await screen.findByText('unlock');
+    await act(async () => {
+      screen.getByText('unlock').click();
+    });
+    expect(screen.getByTestId('status')).toHaveTextContent('unlocked');
+  });
+
+  it('unlockVault with the wrong password throws and stays locked', async () => {
+    const wrong = deriveKeys(new Uint8Array(32).fill(42));
+    localStorage.setItem('cortex_vault_id', 'v1');
+    saveVerifier('v1', await createVerifier(wrong.metadataEncryptionKey));
+    api.getVaultSalt.mockResolvedValue(SALT);
+
+    render(
+      <SessionProvider>
+        <Probe />
+      </SessionProvider>,
+    );
+    await screen.findByText('unlock');
+    await act(async () => {
+      screen.getByText('unlock').click();
+    });
+    expect(document.title).toBe('Incorrect vault password');
+    expect(screen.getByTestId('status')).toHaveTextContent('signedInVaultLocked');
+  });
+
+  it('unlockVault hard-fails (does not unlock) when the verifier is missing', async () => {
+    localStorage.setItem('cortex_vault_id', 'v1'); // vault id present, but no verifier blob
+    api.getVaultSalt.mockResolvedValue(SALT);
+
+    render(
+      <SessionProvider>
+        <Probe />
+      </SessionProvider>,
+    );
+    await screen.findByText('unlock');
+    await act(async () => {
+      screen.getByText('unlock').click();
+    });
+    expect(document.title).toMatch(/verifier missing/i);
+    expect(screen.getByTestId('status')).toHaveTextContent('signedInVaultLocked');
+  });
+});

--- a/packages/web/src/auth/guards.test.tsx
+++ b/packages/web/src/auth/guards.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import type { ReactNode } from 'react';
+
+const state = vi.hoisted(() => ({ status: 'signedOut' as string }));
+vi.mock('./SessionContext', () => ({ useSession: () => ({ status: state.status }) }));
+
+import { RequireAuth, RequireVault } from './guards';
+
+function renderAt(path: string, ui: ReactNode) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/login" element={<div>login-screen</div>} />
+        <Route path="/vault/unlock" element={<div>unlock-screen</div>} />
+        <Route path="/vault/setup" element={<div>setup-screen</div>} />
+        <Route path="/secret" element={ui} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('guards', () => {
+  it('RequireAuth redirects to /login when signedOut', () => {
+    state.status = 'signedOut';
+    renderAt('/secret', <RequireAuth><div>protected</div></RequireAuth>);
+    expect(screen.getByText('login-screen')).toBeInTheDocument();
+  });
+
+  it('RequireAuth renders children when unlocked', () => {
+    state.status = 'unlocked';
+    renderAt('/secret', <RequireAuth><div>protected</div></RequireAuth>);
+    expect(screen.getByText('protected')).toBeInTheDocument();
+  });
+
+  it('RequireVault redirects locked user to /vault/setup when no vault id', () => {
+    state.status = 'signedInVaultLocked';
+    localStorage.removeItem('cortex_vault_id');
+    renderAt('/secret', <RequireVault><div>vault-content</div></RequireVault>);
+    expect(screen.getByText('setup-screen')).toBeInTheDocument();
+  });
+
+  it('RequireVault redirects locked user to /vault/unlock when vault id exists', () => {
+    state.status = 'signedInVaultLocked';
+    localStorage.setItem('cortex_vault_id', 'v1');
+    renderAt('/secret', <RequireVault><div>vault-content</div></RequireVault>);
+    expect(screen.getByText('unlock-screen')).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/auth/guards.tsx
+++ b/packages/web/src/auth/guards.tsx
@@ -1,0 +1,21 @@
+import { Navigate } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import { useSession } from './SessionContext';
+
+export function RequireAuth({ children }: { children: ReactNode }) {
+  const { status } = useSession();
+  if (status === 'loading') return null;
+  if (status === 'signedOut') return <Navigate to="/login" replace />;
+  return <>{children}</>;
+}
+
+export function RequireVault({ children }: { children: ReactNode }) {
+  const { status } = useSession();
+  if (status === 'loading') return null;
+  if (status === 'signedOut') return <Navigate to="/login" replace />;
+  if (status !== 'unlocked') {
+    const hasVault = !!localStorage.getItem('cortex_vault_id');
+    return <Navigate to={hasVault ? '/vault/unlock' : '/vault/setup'} replace />;
+  }
+  return <>{children}</>;
+}

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -1,0 +1,12 @@
+import { useSession } from '../auth/SessionContext';
+
+export default function Dashboard() {
+  const { logout } = useSession();
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Dashboard</h1>
+      <p>Your vault is unlocked. File management arrives in the next slice.</p>
+      <button onClick={() => logout()}>Log out</button>
+    </div>
+  );
+}

--- a/packages/web/src/components/Login.tsx
+++ b/packages/web/src/components/Login.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useSession } from '../auth/SessionContext';
+
+export default function Login() {
+  const { signInAccount } = useSession();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    try {
+      await signInAccount(email, password);
+      // Land on '/'; the RequireAuth + RequireVault guards forward to vault unlock/setup.
+      navigate('/');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Login failed');
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit}>
+      <h1>Log in</h1>
+      <label>
+        Email
+        <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+      </label>
+      <label>
+        Password
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+      </label>
+      {error && <p role="alert">{error}</p>}
+      <button type="submit">Log in</button>
+    </form>
+  );
+}

--- a/packages/web/src/components/Signup.tsx
+++ b/packages/web/src/components/Signup.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useSession } from '../auth/SessionContext';
+
+export default function Signup() {
+  const { signUpAccount } = useSession();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    try {
+      await signUpAccount(email, password);
+      // The vault password is chosen later, during vault setup — not here.
+      navigate('/verify', { state: { email } });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Sign up failed');
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit}>
+      <h1>Create your Cortex account</h1>
+      <label>
+        Email
+        <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+      </label>
+      <label>
+        Password
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+      </label>
+      {error && <p role="alert">{error}</p>}
+      <button type="submit">Sign up</button>
+    </form>
+  );
+}

--- a/packages/web/src/components/VaultSetup.tsx
+++ b/packages/web/src/components/VaultSetup.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useSession } from '../auth/SessionContext';
+
+export default function VaultSetup() {
+  const { setupVault } = useSession();
+  const navigate = useNavigate();
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [recovery, setRecovery] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState('');
+
+  async function onCreate(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    if (password !== confirm) {
+      setError('Vault passwords do not match');
+      return;
+    }
+    try {
+      setRecovery(await setupVault(password));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Vault setup failed');
+    }
+  }
+
+  if (recovery) {
+    return (
+      <div>
+        <h1>Save your recovery phrase</h1>
+        <p>
+          This 24-word phrase is the only way to recover your vault if you forget your vault
+          password. Store it offline. It will not be shown again.
+        </p>
+        <pre>{recovery}</pre>
+        <label>
+          <input type="checkbox" checked={saved} onChange={(e) => setSaved(e.target.checked)} /> I
+          have saved my recovery phrase
+        </label>
+        <button disabled={!saved} onClick={() => navigate('/')}>
+          Continue
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onCreate}>
+      <h1>Set up your vault</h1>
+      <p>Use a different password than your account password.</p>
+      <label>
+        Vault password
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+      </label>
+      <label>
+        Confirm vault password
+        <input
+          type="password"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          required
+        />
+      </label>
+      {error && <p role="alert">{error}</p>}
+      <button type="submit">Create vault</button>
+    </form>
+  );
+}

--- a/packages/web/src/components/VaultUnlock.tsx
+++ b/packages/web/src/components/VaultUnlock.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useSession } from '../auth/SessionContext';
+
+export default function VaultUnlock() {
+  const { unlockVault } = useSession();
+  const navigate = useNavigate();
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    try {
+      await unlockVault(password);
+      navigate('/');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unlock failed');
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit}>
+      <h1>Unlock your vault</h1>
+      <label>
+        Vault password
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+      </label>
+      {error && <p role="alert">{error}</p>}
+      <button type="submit">Unlock</button>
+    </form>
+  );
+}

--- a/packages/web/src/components/VerifyEmail.tsx
+++ b/packages/web/src/components/VerifyEmail.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useSession } from '../auth/SessionContext';
+
+export default function VerifyEmail() {
+  const { confirmAccount } = useSession();
+  const navigate = useNavigate();
+  const passedEmail = (useLocation().state as { email?: string } | null)?.email ?? '';
+  const [email, setEmail] = useState(passedEmail);
+  const [code, setCode] = useState('');
+  const [error, setError] = useState('');
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    try {
+      await confirmAccount(email, code);
+      navigate('/login');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Verification failed');
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit}>
+      <h1>Verify your email</h1>
+      <label>
+        Email
+        <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+      </label>
+      <label>
+        Verification code
+        <input value={code} onChange={(e) => setCode(e.target.value)} required />
+      </label>
+      {error && <p role="alert">{error}</p>}
+      <button type="submit">Verify</button>
+    </form>
+  );
+}

--- a/packages/web/src/components/auth-screens.test.tsx
+++ b/packages/web/src/components/auth-screens.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+const { session, navigate } = vi.hoisted(() => ({
+  session: {
+    signUpAccount: vi.fn(async () => {}),
+    confirmAccount: vi.fn(async () => {}),
+    signInAccount: vi.fn(async () => {}),
+  },
+  navigate: vi.fn(),
+}));
+vi.mock('../auth/SessionContext', () => ({ useSession: () => session }));
+vi.mock('react-router-dom', async (o) => ({
+  ...(await o<typeof import('react-router-dom')>()),
+  useNavigate: () => navigate,
+}));
+
+import Signup from './Signup';
+import Login from './Login';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('auth screens', () => {
+  it('Signup calls signUpAccount with email + account password and navigates to /verify', async () => {
+    render(
+      <MemoryRouter>
+        <Signup />
+      </MemoryRouter>,
+    );
+    await userEvent.type(screen.getByLabelText(/email/i), 'a@b.com');
+    await userEvent.type(screen.getByLabelText(/password/i), 'Abcdefg1!2345');
+    await userEvent.click(screen.getByRole('button', { name: /sign up/i }));
+    expect(session.signUpAccount).toHaveBeenCalledWith('a@b.com', 'Abcdefg1!2345');
+    expect(navigate).toHaveBeenCalledWith('/verify', { state: { email: 'a@b.com' } });
+  });
+
+  it('Login calls signInAccount and navigates to / on success', async () => {
+    render(
+      <MemoryRouter>
+        <Login />
+      </MemoryRouter>,
+    );
+    await userEvent.type(screen.getByLabelText(/email/i), 'a@b.com');
+    await userEvent.type(screen.getByLabelText(/password/i), 'Abcdefg1!2345');
+    await userEvent.click(screen.getByRole('button', { name: /log in/i }));
+    expect(session.signInAccount).toHaveBeenCalledWith('a@b.com', 'Abcdefg1!2345');
+    expect(navigate).toHaveBeenCalledWith('/');
+  });
+});

--- a/packages/web/src/components/vault-screens.test.tsx
+++ b/packages/web/src/components/vault-screens.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+const RECOVERY =
+  'alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima mike november oscar papa quebec romeo sierra tango uniform victor whiskey xray';
+
+const { session, navigate } = vi.hoisted(() => ({
+  session: {
+    setupVault: vi.fn(async () => '__RECOVERY__'),
+    unlockVault: vi.fn(async () => {}),
+  },
+  navigate: vi.fn(),
+}));
+vi.mock('../auth/SessionContext', () => ({ useSession: () => session }));
+vi.mock('react-router-dom', async (o) => ({
+  ...(await o<typeof import('react-router-dom')>()),
+  useNavigate: () => navigate,
+}));
+
+import VaultSetup from './VaultSetup';
+import VaultUnlock from './VaultUnlock';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  session.setupVault.mockResolvedValue(RECOVERY);
+});
+
+describe('vault screens', () => {
+  it('VaultSetup shows the recovery phrase and gates navigation on the checkbox', async () => {
+    render(
+      <MemoryRouter>
+        <VaultSetup />
+      </MemoryRouter>,
+    );
+    await userEvent.type(screen.getByLabelText(/^vault password/i), 'VaultPw123456!');
+    await userEvent.type(screen.getByLabelText(/confirm/i), 'VaultPw123456!');
+    await userEvent.click(screen.getByRole('button', { name: /create vault/i }));
+    expect(session.setupVault).toHaveBeenCalledWith('VaultPw123456!');
+
+    expect(await screen.findByText(/whiskey xray/)).toBeInTheDocument();
+    const cont = screen.getByRole('button', { name: /continue/i });
+    expect(cont).toBeDisabled();
+    await userEvent.click(screen.getByLabelText(/i have saved/i));
+    expect(cont).toBeEnabled();
+    await userEvent.click(cont);
+    expect(navigate).toHaveBeenCalledWith('/');
+  });
+
+  it('VaultSetup blocks mismatched passwords without calling setupVault', async () => {
+    render(
+      <MemoryRouter>
+        <VaultSetup />
+      </MemoryRouter>,
+    );
+    await userEvent.type(screen.getByLabelText(/^vault password/i), 'VaultPw123456!');
+    await userEvent.type(screen.getByLabelText(/confirm/i), 'different');
+    await userEvent.click(screen.getByRole('button', { name: /create vault/i }));
+    expect(session.setupVault).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent(/do not match/i);
+  });
+
+  it('VaultUnlock surfaces an incorrect-password error', async () => {
+    session.unlockVault.mockRejectedValueOnce(new Error('Incorrect vault password'));
+    render(
+      <MemoryRouter>
+        <VaultUnlock />
+      </MemoryRouter>,
+    );
+    await userEvent.type(screen.getByLabelText(/vault password/i), 'wrong');
+    await userEvent.click(screen.getByRole('button', { name: /unlock/i }));
+    expect(await screen.findByText('Incorrect vault password')).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/config.test.ts
+++ b/packages/web/src/config.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { getConfig } from './config';
+
+describe('getConfig', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns all four values when env vars are set', () => {
+    vi.stubEnv('VITE_USER_POOL_ID', 'us-east-1_abc');
+    vi.stubEnv('VITE_USER_POOL_CLIENT_ID', 'client123');
+    vi.stubEnv('VITE_AWS_REGION', 'us-east-1');
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.com');
+    expect(getConfig()).toEqual({
+      userPoolId: 'us-east-1_abc',
+      userPoolClientId: 'client123',
+      region: 'us-east-1',
+      apiBaseUrl: 'https://api.example.com',
+    });
+  });
+
+  it('throws naming the missing var', () => {
+    vi.stubEnv('VITE_USER_POOL_ID', '');
+    vi.stubEnv('VITE_USER_POOL_CLIENT_ID', 'client123');
+    vi.stubEnv('VITE_AWS_REGION', 'us-east-1');
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.com');
+    expect(() => getConfig()).toThrow('VITE_USER_POOL_ID');
+  });
+});

--- a/packages/web/src/config.test.ts
+++ b/packages/web/src/config.test.ts
@@ -6,15 +6,13 @@ describe('getConfig', () => {
     vi.unstubAllEnvs();
   });
 
-  it('returns all four values when env vars are set', () => {
+  it('returns the configured values when env vars are set', () => {
     vi.stubEnv('VITE_USER_POOL_ID', 'us-east-1_abc');
     vi.stubEnv('VITE_USER_POOL_CLIENT_ID', 'client123');
-    vi.stubEnv('VITE_AWS_REGION', 'us-east-1');
     vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.com');
     expect(getConfig()).toEqual({
       userPoolId: 'us-east-1_abc',
       userPoolClientId: 'client123',
-      region: 'us-east-1',
       apiBaseUrl: 'https://api.example.com',
     });
   });
@@ -22,7 +20,6 @@ describe('getConfig', () => {
   it('throws naming the missing var', () => {
     vi.stubEnv('VITE_USER_POOL_ID', '');
     vi.stubEnv('VITE_USER_POOL_CLIENT_ID', 'client123');
-    vi.stubEnv('VITE_AWS_REGION', 'us-east-1');
     vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.com');
     expect(() => getConfig()).toThrow('VITE_USER_POOL_ID');
   });

--- a/packages/web/src/config.ts
+++ b/packages/web/src/config.ts
@@ -1,0 +1,27 @@
+export interface AppConfig {
+  userPoolId: string;
+  userPoolClientId: string;
+  region: string;
+  apiBaseUrl: string;
+}
+
+export function getConfig(): AppConfig {
+  // Static member access only — Vite replaces `import.meta.env.VITE_*` literals at
+  // build time; bracket/dynamic access is NOT replaced and breaks in production.
+  const userPoolId = import.meta.env.VITE_USER_POOL_ID;
+  const userPoolClientId = import.meta.env.VITE_USER_POOL_CLIENT_ID;
+  const region = import.meta.env.VITE_AWS_REGION;
+  const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
+
+  const missing = Object.entries({
+    VITE_USER_POOL_ID: userPoolId,
+    VITE_USER_POOL_CLIENT_ID: userPoolClientId,
+    VITE_AWS_REGION: region,
+    VITE_API_BASE_URL: apiBaseUrl,
+  })
+    .filter(([, v]) => !v)
+    .map(([k]) => k);
+  if (missing.length) throw new Error(`Missing required env var: ${missing.join(', ')}`);
+
+  return { userPoolId, userPoolClientId, region, apiBaseUrl };
+}

--- a/packages/web/src/config.ts
+++ b/packages/web/src/config.ts
@@ -1,27 +1,25 @@
 export interface AppConfig {
   userPoolId: string;
   userPoolClientId: string;
-  region: string;
   apiBaseUrl: string;
 }
 
 export function getConfig(): AppConfig {
   // Static member access only — Vite replaces `import.meta.env.VITE_*` literals at
   // build time; bracket/dynamic access is NOT replaced and breaks in production.
+  // Region is intentionally omitted: Amplify v6 infers it from the userPoolId prefix.
   const userPoolId = import.meta.env.VITE_USER_POOL_ID;
   const userPoolClientId = import.meta.env.VITE_USER_POOL_CLIENT_ID;
-  const region = import.meta.env.VITE_AWS_REGION;
   const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
 
   const missing = Object.entries({
     VITE_USER_POOL_ID: userPoolId,
     VITE_USER_POOL_CLIENT_ID: userPoolClientId,
-    VITE_AWS_REGION: region,
     VITE_API_BASE_URL: apiBaseUrl,
   })
     .filter(([, v]) => !v)
     .map(([k]) => k);
   if (missing.length) throw new Error(`Missing required env var: ${missing.join(', ')}`);
 
-  return { userPoolId, userPoolClientId, region, apiBaseUrl };
+  return { userPoolId, userPoolClientId, apiBaseUrl };
 }

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { Amplify } from 'aws-amplify';
 import App from './App';
+import { getConfig } from './config';
+
+const c = getConfig();
+Amplify.configure({
+  Auth: { Cognito: { userPoolId: c.userPoolId, userPoolClientId: c.userPoolClientId } },
+});
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/packages/web/src/test-setup.ts
+++ b/packages/web/src/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/packages/web/src/test-setup.ts
+++ b/packages/web/src/test-setup.ts
@@ -1,1 +1,32 @@
 import '@testing-library/jest-dom';
+
+// Node 24+ exposes a global `localStorage` that is `undefined` unless `--localstorage-file`
+// is provided, and it shadows jsdom's. Install a deterministic in-memory Storage so the
+// app's bare `localStorage.*` calls work under test.
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+  get length(): number {
+    return this.store.size;
+  }
+  clear(): void {
+    this.store.clear();
+  }
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+}
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: new MemoryStorage(),
+  configurable: true,
+  writable: true,
+});

--- a/packages/web/src/vault/verifier.test.ts
+++ b/packages/web/src/vault/verifier.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { deriveKeys } from '@cortex/encryption';
+import { createVerifier, checkVerifier } from './verifier';
+
+function keysFrom(seed: number) {
+  return deriveKeys(new Uint8Array(32).fill(seed));
+}
+
+describe('vault verifier', () => {
+  it('verifies with the correct metadata key', async () => {
+    const keys = keysFrom(1);
+    const blob = await createVerifier(keys.metadataEncryptionKey);
+    expect(checkVerifier(blob, keys.metadataEncryptionKey)).toBe(true);
+  });
+
+  it('rejects a wrong metadata key', async () => {
+    const right = keysFrom(1);
+    const wrong = keysFrom(2);
+    const blob = await createVerifier(right.metadataEncryptionKey);
+    expect(checkVerifier(blob, wrong.metadataEncryptionKey)).toBe(false);
+  });
+
+  it('rejects a corrupted blob without throwing', () => {
+    const keys = keysFrom(1);
+    expect(checkVerifier('not-base64-or-valid', keys.metadataEncryptionKey)).toBe(false);
+  });
+});

--- a/packages/web/src/vault/verifier.ts
+++ b/packages/web/src/vault/verifier.ts
@@ -1,0 +1,33 @@
+import {
+  encrypt,
+  decrypt,
+  stringToBytes,
+  bytesToString,
+  bytesToBase64,
+  base64ToBytes,
+} from '@cortex/encryption';
+
+const VERIFIER_CONSTANT = 'cortex-vault-verifier-v1';
+const STORAGE_PREFIX = 'cortex_vault_verifier_';
+
+export async function createVerifier(metadataKey: Uint8Array): Promise<string> {
+  const ct = await encrypt(stringToBytes(VERIFIER_CONSTANT), metadataKey);
+  return bytesToBase64(ct);
+}
+
+export function checkVerifier(stored: string, metadataKey: Uint8Array): boolean {
+  try {
+    const pt = decrypt(base64ToBytes(stored), metadataKey);
+    return bytesToString(pt) === VERIFIER_CONSTANT;
+  } catch {
+    return false;
+  }
+}
+
+export function saveVerifier(vaultId: string, blob: string): void {
+  localStorage.setItem(STORAGE_PREFIX + vaultId, blob);
+}
+
+export function loadVerifier(vaultId: string): string | null {
+  return localStorage.getItem(STORAGE_PREFIX + vaultId);
+}

--- a/packages/web/src/vite-env.d.ts
+++ b/packages/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
@@ -9,5 +10,10 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     sourcemap: true,
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test-setup.ts'],
   },
 });


### PR DESCRIPTION
## What

The first usable, secure slice of `@cortex/web`: **sign up → verify email → log in → set up vault (recovery phrase) → unlock → authenticated dashboard → logout.** This delivers the two-password zero-knowledge model end-to-end (task 7.1–7.2), without file management yet.

- **Account auth** → Cognito via **Amplify v6** (SRP, self-signup, email-code verify).
- **Vault** → client-side **Argon2id → `deriveKeys()` → KEK** (the keys never leave the browser); salt is fetched from the server.
- Router + `RequireAuth`/`RequireVault` guards, authed API client (JWT bearer), `SessionContext` status machine (`loading → signedOut → signedInVaultLocked → unlocked`), and a client-side vault-password verifier.

## Flows
- **Signup:** `signUp` → email code → `confirmSignUp` → `signIn` → **VaultSetup** (`POST /v1/vaults` → server salt → derive keys → show 24-word BIP39 phrase behind an "I've saved it" gate) → Dashboard.
- **Login:** `signIn` → **VaultUnlock** (`GET /v1/vaults/{id}/salt` → derive keys → verify → store) → Dashboard.

## Bundled encryption fixes (prerequisites surfaced by being the first browser consumer of `@cortex/encryption`)
- `@noble/ciphers`/`@noble/hashes` **v2 `.js` subpath imports** — jest tolerated the v1 paths; Vite (and the prod build) did not.
- **Argon2id browser bundling:** swapped the `argon2id` WASM package (loose `.wasm` + Node `fs` loader, unbundleable) for **`hash-wasm`** (inlines WASM as base64, no Node APIs). **Byte-identical**, verified via an RFC 9106 known-answer vector across implementations. Deletes ~120 lines of dual Node/browser loader and un-skips the `deriveVaultMasterKey` tests.
- **CI:** `js-tests` now builds `@cortex/encryption` before web tests (web imports its compiled `dist`).

## Verification
- Encryption jest: **196 passed** · Web vitest: **25 passed / 9 files** · `tsc --noEmit`: clean · `vite build`: succeeds (both packages).
- This is the **first web test suite** in the repo, so the `js-tests` workflow's `--passWithNoTests` now flips to real `packages/web` coverage.

## Review notes (folded-in findings)
- Login now navigates to `/` on success (a returning-user dead-end the tests passed *through*).
- `unlockVault` hard-fails on a missing verifier (no silent unlock with wrong keys).
- VaultSetup has a confirm field (a vault-password typo = data loss).

## Out of scope / follow-ups
File upload/list/download (Slice 2), collections/tags (Slice 3), MFA UI, forgot-password, multi-device vault discovery + server-side verifier, full key zeroization. Not yet smoke-tested against a live Cognito pool (needs a real `.env`). Design/plan docs live under `docs/` (not committed, per project convention).