### PR TITLE
feat(web): Phase B Slice 2 — file management (upload/list/download/delete on Smithy SDK)

### DIFF
--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -9,8 +9,11 @@ import { getConfig } from '../config';
  * @httpBearerAuth). The generated restJson1 serde honors the camelCase contract
  * and marshals Blob fields as Uint8Array<->base64, so callers work in raw bytes
  * — no manual casing or base64 handling here.
+ *
+ * Exported so sibling API modules (e.g. ./items) send their own commands through
+ * the same endpoint + Cognito-bearer configuration.
  */
-function makeClient(): CortexClient {
+export function makeClient(): CortexClient {
   const { apiBaseUrl } = getConfig();
   return new CortexClient({
     endpoint: apiBaseUrl,

--- a/packages/web/src/api/items.test.ts
+++ b/packages/web/src/api/items.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Same convention as client.test.ts: the generated SDK owns HTTP/auth/serde, so we
+// mock @cortex/client and assert which command was sent with which input. Only
+// putToS3 hits the network directly (presigned URL is not a Smithy op).
+const { sendMock, commands } = vi.hoisted(() => ({
+  sendMock: vi.fn(),
+  commands: [] as Array<[string, unknown]>,
+}));
+
+vi.mock('@cortex/client', () => ({
+  CortexClient: class {
+    send = sendMock;
+    constructor(public config: unknown) {}
+  },
+  InitiateItemUploadCommand: class {
+    constructor(public input: unknown) { commands.push(['InitiateItemUpload', input]); }
+  },
+  CompleteItemUploadCommand: class {
+    constructor(public input: unknown) { commands.push(['CompleteItemUpload', input]); }
+  },
+  ListItemsCommand: class {
+    constructor(public input: unknown) { commands.push(['ListItems', input]); }
+  },
+  GetItemDownloadUrlCommand: class {
+    constructor(public input: unknown) { commands.push(['GetItemDownloadUrl', input]); }
+  },
+  DeleteItemCommand: class {
+    constructor(public input: unknown) { commands.push(['DeleteItem', input]); }
+  },
+}));
+vi.mock('aws-amplify/auth', () => ({
+  fetchAuthSession: vi.fn(async () => ({ tokens: { idToken: { toString: () => 'JWT' } } })),
+}));
+vi.mock('../config', () => ({ getConfig: () => ({ apiBaseUrl: 'https://api' }) }));
+
+import { initiateUpload, putToS3, completeUpload, listItems, getDownloadUrl, deleteItem } from './items';
+
+beforeEach(() => {
+  sendMock.mockReset();
+  commands.length = 0;
+  vi.unstubAllGlobals();
+});
+
+describe('items api', () => {
+  it('initiateUpload sends the command and returns itemId+uploadUrl', async () => {
+    sendMock.mockResolvedValueOnce({ itemId: 'i1', uploadUrl: 'https://s3/put', expiresAt: new Date(0) });
+    const meta = new Uint8Array([1, 2, 3]);
+    const out = await initiateUpload({ vaultId: 'v1', encryptedMetadata: meta, sizeBytes: 200 });
+    expect(out).toEqual({ itemId: 'i1', uploadUrl: 'https://s3/put' });
+    expect(commands).toContainEqual(['InitiateItemUpload', { vaultId: 'v1', encryptedMetadata: meta, sizeBytes: 200 }]);
+  });
+
+  it('putToS3 PUTs raw bytes with NO Authorization header', async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const blob = new Uint8Array([1, 2, 3]);
+    await putToS3('https://s3/put', blob);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('https://s3/put');
+    expect(init.method).toBe('PUT');
+    expect(init.body).toBe(blob);
+    expect((init.headers as Record<string, string>).Authorization).toBeUndefined();
+  });
+
+  it('putToS3 throws on a non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(null, { status: 403 })));
+    await expect(putToS3('https://s3/put', new Uint8Array([1]))).rejects.toThrow('403');
+  });
+
+  it('completeUpload sends the command with the itemId', async () => {
+    sendMock.mockResolvedValueOnce({ itemId: 'i1', completedAt: new Date(0) });
+    await completeUpload('i1');
+    expect(commands).toContainEqual(['CompleteItemUpload', { itemId: 'i1' }]);
+  });
+
+  it('listItems sends vaultId and returns items', async () => {
+    const items = [{ itemId: 'i1', encryptedMetadata: new Uint8Array([9]), createdAt: new Date(0) }];
+    sendMock.mockResolvedValueOnce({ items, totalCount: 1 });
+    const out = await listItems('v1');
+    expect(out).toBe(items);
+    expect(commands).toContainEqual(['ListItems', { vaultId: 'v1' }]);
+  });
+
+  it('listItems returns [] when items is absent', async () => {
+    sendMock.mockResolvedValueOnce({ totalCount: 0 });
+    expect(await listItems('v1')).toEqual([]);
+  });
+
+  it('getDownloadUrl returns the url', async () => {
+    sendMock.mockResolvedValueOnce({ downloadUrl: 'https://s3/get', expiresAt: new Date(0) });
+    expect(await getDownloadUrl('i1')).toBe('https://s3/get');
+    expect(commands).toContainEqual(['GetItemDownloadUrl', { itemId: 'i1' }]);
+  });
+
+  it('deleteItem sends the command with the itemId', async () => {
+    sendMock.mockResolvedValueOnce({ message: 'ok', deletedAt: new Date(0) });
+    await deleteItem('i1');
+    expect(commands).toContainEqual(['DeleteItem', { itemId: 'i1' }]);
+  });
+});

--- a/packages/web/src/api/items.ts
+++ b/packages/web/src/api/items.ts
@@ -1,0 +1,54 @@
+import {
+  InitiateItemUploadCommand,
+  CompleteItemUploadCommand,
+  ListItemsCommand,
+  GetItemDownloadUrlCommand,
+  DeleteItemCommand,
+} from '@cortex/client';
+import type { ItemData } from '@cortex/client';
+import { makeClient } from './client';
+
+export type { ItemData };
+
+export async function initiateUpload(args: {
+  vaultId: string;
+  encryptedMetadata: Uint8Array;
+  sizeBytes: number;
+}): Promise<{ itemId: string; uploadUrl: string }> {
+  const out = await makeClient().send(new InitiateItemUploadCommand(args));
+  if (!out.itemId || !out.uploadUrl) throw new Error('initiateUpload: incomplete response');
+  return { itemId: out.itemId, uploadUrl: out.uploadUrl };
+}
+
+export async function putToS3(uploadUrl: string, blob: Uint8Array): Promise<void> {
+  // Raw PUT to the presigned URL — not a Smithy op, so no Authorization header
+  // (the URL carries auth). The body is opaque ciphertext → octet-stream; the
+  // real MIME lives only in the encrypted metadata.
+  const res = await fetch(uploadUrl, {
+    method: 'PUT',
+    // ponytail: cast needed because lib.dom's BodyInit rejects Uint8Array<ArrayBufferLike>
+    // (it wants an ArrayBuffer-backed view). Runtime body is still the exact blob.
+    body: blob as BodyInit,
+    headers: { 'Content-Type': 'application/octet-stream' },
+  });
+  if (!res.ok) throw new Error(`S3 upload failed: ${res.status}`);
+}
+
+export async function completeUpload(itemId: string): Promise<void> {
+  await makeClient().send(new CompleteItemUploadCommand({ itemId }));
+}
+
+export async function listItems(vaultId: string): Promise<ItemData[]> {
+  const out = await makeClient().send(new ListItemsCommand({ vaultId }));
+  return out.items ?? [];
+}
+
+export async function getDownloadUrl(itemId: string): Promise<string> {
+  const out = await makeClient().send(new GetItemDownloadUrlCommand({ itemId }));
+  if (!out.downloadUrl) throw new Error('getDownloadUrl: missing download URL');
+  return out.downloadUrl;
+}
+
+export async function deleteItem(itemId: string): Promise<void> {
+  await makeClient().send(new DeleteItemCommand({ itemId }));
+}

--- a/packages/web/src/api/items.ts
+++ b/packages/web/src/api/items.ts
@@ -8,8 +8,6 @@ import {
 import type { ItemData } from '@cortex/client';
 import { makeClient } from './client';
 
-export type { ItemData };
-
 export async function initiateUpload(args: {
   vaultId: string;
   encryptedMetadata: Uint8Array;

--- a/packages/web/src/components/Dashboard.test.tsx
+++ b/packages/web/src/components/Dashboard.test.tsx
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('../auth/SessionContext', () => ({ useSession: () => ({ logout: vi.fn() }) }));
+vi.mock('./FileUpload', () => ({ default: () => <div>file-upload</div>, MAX_FILE_SIZE_BYTES: 1 }));
+vi.mock('./FileList', () => ({ default: ({ refreshKey }: { refreshKey: number }) => <div>file-list:{refreshKey}</div> }));
+
+import Dashboard from './Dashboard';
+
+describe('Dashboard', () => {
+  it('shows the upload control and the file list', () => {
+    render(<Dashboard />);
+    expect(screen.getByText('file-upload')).toBeInTheDocument();
+    expect(screen.getByText(/file-list:/)).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -1,11 +1,17 @@
+import { useState } from 'react';
 import { useSession } from '../auth/SessionContext';
+import FileUpload from './FileUpload';
+import FileList from './FileList';
 
 export default function Dashboard() {
   const { logout } = useSession();
+  const [refreshKey, setRefreshKey] = useState(0);
+
   return (
     <div style={{ padding: '2rem' }}>
       <h1>Dashboard</h1>
-      <p>Your vault is unlocked. File management arrives in the next slice.</p>
+      <FileUpload onUploaded={() => setRefreshKey((k) => k + 1)} />
+      <FileList refreshKey={refreshKey} />
       <button onClick={() => logout()}>Log out</button>
     </div>
   );

--- a/packages/web/src/components/FileList.test.tsx
+++ b/packages/web/src/components/FileList.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const h = vi.hoisted(() => ({
+  getVaultKeys: vi.fn(async () => ({ vaultId: 'v1', kek: new Uint8Array(32), metadataKey: new Uint8Array(32) })),
+  listItems: vi.fn(async () => [{ itemId: 'i1', encryptedMetadata: new Uint8Array([1]), createdAt: new Date(1000) }]),
+  getDownloadUrl: vi.fn(async () => 'https://s3/get'),
+  deleteItem: vi.fn(async () => {}),
+  decryptMetadata: vi.fn(() => ({ name: 'cat.png', contentType: 'image/png', size: 1234, contentId: 'c1' })),
+  decryptDownloadedBlob: vi.fn(() => new Uint8Array([1, 2, 3])),
+}));
+vi.mock('../vault/keyAccess', () => ({ getVaultKeys: h.getVaultKeys }));
+vi.mock('../api/items', () => ({ listItems: h.listItems, getDownloadUrl: h.getDownloadUrl, deleteItem: h.deleteItem }));
+vi.mock('../items/metadata', () => ({ decryptMetadata: h.decryptMetadata }));
+vi.mock('../items/itemCrypto', () => ({ decryptDownloadedBlob: h.decryptDownloadedBlob }));
+
+import FileList from './FileList';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal('fetch', vi.fn(async () => new Response(new Uint8Array([9]).buffer)));
+  // jsdom lacks these; stub so the download path doesn't crash.
+  vi.stubGlobal('URL', { ...URL, createObjectURL: vi.fn(() => 'blob:x'), revokeObjectURL: vi.fn() });
+});
+
+describe('FileList', () => {
+  it('renders a decrypted row', async () => {
+    render(<FileList refreshKey={0} />);
+    expect(await screen.findByText('cat.png')).toBeInTheDocument();
+  });
+
+  it('download fetches the url, decrypts, and triggers a save', async () => {
+    render(<FileList refreshKey={0} />);
+    await screen.findByText('cat.png');
+    await userEvent.click(screen.getByRole('button', { name: /download/i }));
+    await waitFor(() => expect(h.getDownloadUrl).toHaveBeenCalledWith('i1'));
+    expect(h.decryptDownloadedBlob).toHaveBeenCalled();
+  });
+
+  it('delete calls the API then reloads the list', async () => {
+    render(<FileList refreshKey={0} />);
+    await screen.findByText('cat.png');
+    await userEvent.click(screen.getByRole('button', { name: /delete/i }));
+    await waitFor(() => expect(h.deleteItem).toHaveBeenCalledWith('i1'));
+    expect(h.listItems).toHaveBeenCalledTimes(2); // initial + after delete
+  });
+});

--- a/packages/web/src/components/FileList.tsx
+++ b/packages/web/src/components/FileList.tsx
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useState } from 'react';
+import { getVaultKeys } from '../vault/keyAccess';
+import { listItems, getDownloadUrl, deleteItem } from '../api/items';
+import { decryptMetadata, type FileMetadata } from '../items/metadata';
+import { decryptDownloadedBlob } from '../items/itemCrypto';
+
+interface Row {
+  itemId: string;
+  createdAt?: Date; // generated ItemData.createdAt is a Date (not epoch seconds)
+  meta: FileMetadata | null; // null = metadata failed to decrypt
+}
+
+export default function FileList({ refreshKey }: { refreshKey: number }) {
+  const [rows, setRows] = useState<Row[]>([]);
+  const [error, setError] = useState('');
+
+  const load = useCallback(async () => {
+    setError('');
+    try {
+      const { vaultId, metadataKey } = await getVaultKeys();
+      const items = await listItems(vaultId);
+      setRows(
+        items
+          .filter((it) => it.itemId)
+          .map((it) => {
+            let meta: FileMetadata | null = null;
+            try {
+              if (it.encryptedMetadata) meta = decryptMetadata(it.encryptedMetadata, metadataKey);
+            } catch {
+              meta = null;
+            }
+            return { itemId: it.itemId!, createdAt: it.createdAt, meta };
+          }),
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not load files');
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load, refreshKey]);
+
+  async function onDownload(row: Row) {
+    if (!row.meta) return;
+    const { kek } = await getVaultKeys();
+    const url = await getDownloadUrl(row.itemId);
+    const blob = new Uint8Array(await (await fetch(url)).arrayBuffer());
+    const plain = decryptDownloadedBlob(blob, row.meta, kek);
+    const objectUrl = URL.createObjectURL(new Blob([plain as BlobPart], { type: row.meta.contentType }));
+    const a = document.createElement('a');
+    a.href = objectUrl;
+    a.download = row.meta.name;
+    a.click();
+    URL.revokeObjectURL(objectUrl);
+  }
+
+  async function onDelete(itemId: string) {
+    await deleteItem(itemId);
+    await load();
+  }
+
+  if (error) return <p role="alert">{error}</p>;
+  if (rows.length === 0) return <p>No files yet.</p>;
+
+  return (
+    <ul>
+      {rows.map((row) => (
+        <li key={row.itemId}>
+          <span>{row.meta ? row.meta.name : '(unreadable)'}</span>
+          {row.meta && <span> · {row.meta.size} bytes</span>}
+          {row.createdAt && <span> · {row.createdAt.toLocaleDateString()}</span>}
+          <button onClick={() => onDownload(row)} disabled={!row.meta}>Download</button>
+          <button onClick={() => onDelete(row.itemId)}>Delete</button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/web/src/components/FileList.tsx
+++ b/packages/web/src/components/FileList.tsx
@@ -20,17 +20,15 @@ export default function FileList({ refreshKey }: { refreshKey: number }) {
       const { vaultId, metadataKey } = await getVaultKeys();
       const items = await listItems(vaultId);
       setRows(
-        items
-          .filter((it) => it.itemId)
-          .map((it) => {
-            let meta: FileMetadata | null = null;
-            try {
-              if (it.encryptedMetadata) meta = decryptMetadata(it.encryptedMetadata, metadataKey);
-            } catch {
-              meta = null;
-            }
-            return { itemId: it.itemId!, createdAt: it.createdAt, meta };
-          }),
+        items.map((it) => {
+          let meta: FileMetadata | null = null;
+          try {
+            if (it.encryptedMetadata) meta = decryptMetadata(it.encryptedMetadata, metadataKey);
+          } catch {
+            // metadata won't decrypt → show the row as unreadable
+          }
+          return { itemId: it.itemId!, createdAt: it.createdAt, meta };
+        }),
       );
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Could not load files');

--- a/packages/web/src/components/FileUpload.test.tsx
+++ b/packages/web/src/components/FileUpload.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const enc = new Uint8Array([7, 7]);
+const h = vi.hoisted(() => ({
+  getVaultKeys: vi.fn(async () => ({ vaultId: 'v1', kek: new Uint8Array(32), metadataKey: new Uint8Array(32) })),
+  encryptFileForUpload: vi.fn(async () => ({ blob: new Uint8Array([9, 9]), encryptedMetadata: new Uint8Array([7, 7]), metadata: {} })),
+  initiateUpload: vi.fn(async () => ({ itemId: 'i1', uploadUrl: 'https://s3/put' })),
+  putToS3: vi.fn(async () => {}),
+  completeUpload: vi.fn(async () => {}),
+}));
+vi.mock('../vault/keyAccess', () => ({ getVaultKeys: h.getVaultKeys }));
+vi.mock('../items/itemCrypto', () => ({ encryptFileForUpload: h.encryptFileForUpload }));
+vi.mock('../api/items', () => ({ initiateUpload: h.initiateUpload, putToS3: h.putToS3, completeUpload: h.completeUpload }));
+
+import FileUpload, { MAX_FILE_SIZE_BYTES } from './FileUpload';
+
+beforeEach(() => vi.clearAllMocks());
+
+function pick(name: string, bytes: number, type = 'image/png') {
+  const file = new File([new Uint8Array(bytes)], name, { type });
+  // jsdom File.size reflects the byte length; override for the over-cap case cheaply:
+  Object.defineProperty(file, 'size', { value: bytes });
+  file.arrayBuffer = async () => new Uint8Array(Math.min(bytes, 4)).buffer;
+  return file;
+}
+
+describe('FileUpload', () => {
+  it('runs init → PUT → complete in order and calls onUploaded', async () => {
+    const onUploaded = vi.fn();
+    render(<FileUpload onUploaded={onUploaded} />);
+    await userEvent.upload(screen.getByLabelText(/upload/i), pick('a.png', 3));
+    await waitFor(() => expect(onUploaded).toHaveBeenCalled());
+    expect(h.encryptFileForUpload).toHaveBeenCalled();
+    expect(h.initiateUpload).toHaveBeenCalledWith({ vaultId: 'v1', encryptedMetadata: enc, sizeBytes: 2 });
+    expect(h.putToS3).toHaveBeenCalledWith('https://s3/put', new Uint8Array([9, 9]));
+    expect(h.completeUpload).toHaveBeenCalledWith('i1');
+  });
+
+  it('rejects files over the cap without uploading', async () => {
+    render(<FileUpload onUploaded={vi.fn()} />);
+    await userEvent.upload(screen.getByLabelText(/upload/i), pick('big.bin', MAX_FILE_SIZE_BYTES + 1));
+    expect(await screen.findByRole('alert')).toHaveTextContent(/100 ?MB/i);
+    expect(h.initiateUpload).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/components/FileUpload.tsx
+++ b/packages/web/src/components/FileUpload.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { getVaultKeys } from '../vault/keyAccess';
+import { encryptFileForUpload } from '../items/itemCrypto';
+import { initiateUpload, putToS3, completeUpload } from '../api/items';
+
+export const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
+
+export default function FileUpload({ onUploaded }: { onUploaded: () => void }) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  async function onChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    e.target.value = ''; // allow re-selecting the same file
+    if (!file) return;
+    setError('');
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      setError("Files over 100 MB aren't supported yet — large-file streaming is coming.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const bytes = new Uint8Array(await file.arrayBuffer());
+      const keys = await getVaultKeys();
+      const { blob, encryptedMetadata } = await encryptFileForUpload(
+        bytes, file.name, file.type || 'application/octet-stream', keys,
+      );
+      const { itemId, uploadUrl } = await initiateUpload({
+        vaultId: keys.vaultId,
+        encryptedMetadata,
+        sizeBytes: blob.length,
+      });
+      await putToS3(uploadUrl, blob);
+      await completeUpload(itemId);
+      onUploaded();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Upload failed');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div>
+      <label>
+        Upload file
+        <input type="file" onChange={onChange} disabled={busy} />
+      </label>
+      {busy && <p>Encrypting and uploading…</p>}
+      {error && <p role="alert">{error}</p>}
+    </div>
+  );
+}

--- a/packages/web/src/items/itemBlob.test.ts
+++ b/packages/web/src/items/itemBlob.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { encodeItemBlob, decodeItemBlob, WRAPPED_DEK_SIZE } from './itemBlob';
+
+describe('item blob codec', () => {
+  it('round-trips wrappedDek + ciphertext', () => {
+    const wrappedDek = new Uint8Array(WRAPPED_DEK_SIZE).fill(7);
+    const ciphertext = new Uint8Array([1, 2, 3, 4, 5]);
+    const blob = encodeItemBlob(wrappedDek, ciphertext);
+    expect(blob.length).toBe(WRAPPED_DEK_SIZE + 5);
+    const out = decodeItemBlob(blob);
+    expect(out.wrappedDek).toEqual(wrappedDek);
+    expect(out.ciphertext).toEqual(ciphertext);
+  });
+
+  it('rejects a wrong-size wrappedDek on encode', () => {
+    expect(() => encodeItemBlob(new Uint8Array(10), new Uint8Array(1))).toThrow('wrapped DEK');
+  });
+
+  it('rejects a blob too short to hold a wrapped DEK', () => {
+    expect(() => decodeItemBlob(new Uint8Array(WRAPPED_DEK_SIZE - 1))).toThrow('too short');
+  });
+});

--- a/packages/web/src/items/itemBlob.ts
+++ b/packages/web/src/items/itemBlob.ts
@@ -1,0 +1,23 @@
+// ponytail: fixed 97-byte prefix assumes HMAC binding is always on. If an unbound
+// (65-byte) path is ever added, switch to a length-prefixed format instead.
+export const WRAPPED_DEK_SIZE = 97;
+
+export function encodeItemBlob(wrappedDek: Uint8Array, ciphertext: Uint8Array): Uint8Array {
+  if (wrappedDek.length !== WRAPPED_DEK_SIZE) {
+    throw new Error(`Invalid wrapped DEK size: expected ${WRAPPED_DEK_SIZE}, got ${wrappedDek.length}`);
+  }
+  const blob = new Uint8Array(WRAPPED_DEK_SIZE + ciphertext.length);
+  blob.set(wrappedDek, 0);
+  blob.set(ciphertext, WRAPPED_DEK_SIZE);
+  return blob;
+}
+
+export function decodeItemBlob(blob: Uint8Array): { wrappedDek: Uint8Array; ciphertext: Uint8Array } {
+  if (blob.length < WRAPPED_DEK_SIZE) {
+    throw new Error(`Item blob too short: ${blob.length} < ${WRAPPED_DEK_SIZE}`);
+  }
+  return {
+    wrappedDek: blob.slice(0, WRAPPED_DEK_SIZE),
+    ciphertext: blob.slice(WRAPPED_DEK_SIZE),
+  };
+}

--- a/packages/web/src/items/itemCrypto.test.ts
+++ b/packages/web/src/items/itemCrypto.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { deriveKeys } from '@cortex/encryption';
+import { encryptFileForUpload, decryptDownloadedBlob } from './itemCrypto';
+import { decryptMetadata } from './metadata';
+
+const keys = (() => {
+  const k = deriveKeys(new Uint8Array(32).fill(5));
+  return { kek: k.keyEncryptionKey, metadataKey: k.metadataEncryptionKey };
+})();
+
+describe('item crypto', () => {
+  it('encrypts then decrypts a file end-to-end', async () => {
+    const bytes = new TextEncoder().encode('the secret photo bytes');
+    const { blob, encryptedMetadata, metadata } = await encryptFileForUpload(
+      bytes, 'photo.jpg', 'image/jpeg', keys,
+    );
+    expect(metadata).toMatchObject({ name: 'photo.jpg', contentType: 'image/jpeg', size: bytes.length });
+    expect(metadata.contentId).toMatch(/[0-9a-f-]{36}/);
+
+    const meta = decryptMetadata(encryptedMetadata, keys.metadataKey);
+    const out = decryptDownloadedBlob(blob, meta, keys.kek);
+    // Array.from both sides: under jsdom, the crypto lib's Uint8Array (Node realm)
+    // and the test's TextEncoder Uint8Array (jsdom realm) are byte-identical but
+    // cross-realm, so toEqual on the raw arrays fails. Comparing plain arrays is
+    // realm-agnostic and still checks every byte.
+    expect(Array.from(out)).toEqual(Array.from(bytes));
+  });
+
+  it('fails the HMAC binding if contentId is tampered', async () => {
+    const bytes = new TextEncoder().encode('x');
+    const { blob, metadata } = await encryptFileForUpload(bytes, 'a', 'text/plain', keys);
+    const tampered = { ...metadata, contentId: 'different-content-id' };
+    expect(() => decryptDownloadedBlob(blob, tampered, keys.kek)).toThrow();
+  });
+});

--- a/packages/web/src/items/itemCrypto.ts
+++ b/packages/web/src/items/itemCrypto.ts
@@ -1,0 +1,27 @@
+import { encryptFileWithDek, decryptFileWithDek } from '@cortex/encryption';
+import { encodeItemBlob, decodeItemBlob } from './itemBlob';
+import { encryptMetadata, type FileMetadata } from './metadata';
+
+export async function encryptFileForUpload(
+  bytes: Uint8Array,
+  name: string,
+  contentType: string,
+  keys: { kek: Uint8Array; metadataKey: Uint8Array },
+): Promise<{ blob: Uint8Array; encryptedMetadata: Uint8Array; metadata: FileMetadata }> {
+  const contentId = crypto.randomUUID();
+  // fileId = contentId binds the DEK to this file (HMAC); wrappedDek is 97 bytes.
+  const { encryptedContent, wrappedDek } = await encryptFileWithDek(bytes, keys.kek, contentId);
+  const blob = encodeItemBlob(wrappedDek, encryptedContent);
+  const metadata: FileMetadata = { name, contentType, size: bytes.length, contentId };
+  const encryptedMetadata = await encryptMetadata(metadata, keys.metadataKey);
+  return { blob, encryptedMetadata, metadata };
+}
+
+export function decryptDownloadedBlob(
+  blob: Uint8Array,
+  metadata: FileMetadata,
+  kek: Uint8Array,
+): Uint8Array {
+  const { wrappedDek, ciphertext } = decodeItemBlob(blob);
+  return decryptFileWithDek(ciphertext, wrappedDek, kek, metadata.contentId);
+}

--- a/packages/web/src/items/metadata.test.ts
+++ b/packages/web/src/items/metadata.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { deriveKeys } from '@cortex/encryption';
+import { encryptMetadata, decryptMetadata, type FileMetadata } from './metadata';
+
+const key = (seed: number) => deriveKeys(new Uint8Array(32).fill(seed)).metadataEncryptionKey;
+const META: FileMetadata = { name: 'cat.png', contentType: 'image/png', size: 1234, contentId: 'id-1' };
+
+describe('file metadata codec', () => {
+  it('round-trips metadata with the correct key', async () => {
+    // Adapted for #208: encryptedMetadata is a Blob (Uint8Array) on the contract;
+    // the SDK base64s it on the wire, so the codec stays in raw bytes.
+    const blob = await encryptMetadata(META, key(1));
+    expect(blob).toBeInstanceOf(Uint8Array);
+    expect(decryptMetadata(blob, key(1))).toEqual(META);
+  });
+
+  it('fails to decrypt with the wrong key', async () => {
+    const blob = await encryptMetadata(META, key(1));
+    expect(() => decryptMetadata(blob, key(2))).toThrow();
+  });
+});

--- a/packages/web/src/items/metadata.ts
+++ b/packages/web/src/items/metadata.ts
@@ -1,0 +1,20 @@
+import { encrypt, decrypt, stringToBytes, bytesToString } from '@cortex/encryption';
+
+export interface FileMetadata {
+  name: string;
+  contentType: string;
+  size: number;
+  contentId: string;
+}
+
+// Adapted for #208: the Smithy `encryptedMetadata` field is a Blob (Uint8Array)
+// that the generated SDK base64-encodes on the wire. So this codec produces and
+// consumes raw ciphertext bytes — no manual base64 (that would double-encode).
+export async function encryptMetadata(meta: FileMetadata, metadataKey: Uint8Array): Promise<Uint8Array> {
+  return encrypt(stringToBytes(JSON.stringify(meta)), metadataKey);
+}
+
+export function decryptMetadata(ciphertext: Uint8Array, metadataKey: Uint8Array): FileMetadata {
+  const json = bytesToString(decrypt(ciphertext, metadataKey));
+  return JSON.parse(json) as FileMetadata;
+}

--- a/packages/web/src/vault/keyAccess.test.ts
+++ b/packages/web/src/vault/keyAccess.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { retrieveKeys } = vi.hoisted(() => ({ retrieveKeys: vi.fn() }));
+vi.mock('@cortex/encryption', () => ({ retrieveKeys }));
+
+import { getVaultKeys } from './keyAccess';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+describe('getVaultKeys', () => {
+  it('returns vaultId + kek + metadataKey from key-storage', async () => {
+    localStorage.setItem('cortex_vault_id', 'v1');
+    retrieveKeys.mockResolvedValue({
+      keyEncryptionKey: new Uint8Array(32).fill(1),
+      metadataEncryptionKey: new Uint8Array(32).fill(2),
+    });
+    const out = await getVaultKeys();
+    expect(out.vaultId).toBe('v1');
+    expect(out.kek).toEqual(new Uint8Array(32).fill(1));
+    expect(out.metadataKey).toEqual(new Uint8Array(32).fill(2));
+    expect(retrieveKeys).toHaveBeenCalledWith('v1');
+  });
+
+  it('throws when there is no vault id', async () => {
+    await expect(getVaultKeys()).rejects.toThrow('locked');
+  });
+
+  it('throws when keys are absent/expired', async () => {
+    localStorage.setItem('cortex_vault_id', 'v1');
+    retrieveKeys.mockResolvedValue(null);
+    await expect(getVaultKeys()).rejects.toThrow('locked');
+  });
+});

--- a/packages/web/src/vault/keyAccess.ts
+++ b/packages/web/src/vault/keyAccess.ts
@@ -1,0 +1,15 @@
+import { retrieveKeys } from '@cortex/encryption';
+
+const VAULT_ID_KEY = 'cortex_vault_id';
+
+export async function getVaultKeys(): Promise<{
+  vaultId: string;
+  kek: Uint8Array;
+  metadataKey: Uint8Array;
+}> {
+  const vaultId = localStorage.getItem(VAULT_ID_KEY);
+  if (!vaultId) throw new Error('Vault is locked — unlock it again');
+  const keys = await retrieveKeys(vaultId);
+  if (!keys) throw new Error('Vault is locked — unlock it again');
+  return { vaultId, kek: keys.keyEncryptionKey, metadataKey: keys.metadataEncryptionKey };
+}


### PR DESCRIPTION
## Phase B · Slice 2 — File Management

An unlocked user can **upload (≤100 MB), list, download, and delete** client-side-encrypted files via presigned S3, with each file's DEK HMAC-bound to a client `contentId`. All crypto via `@cortex/encryption`; only ciphertext (→S3) and encrypted metadata (→item record) cross the wire — the real filename/MIME live only inside the encrypted metadata.

Built TDD, leaf-up (8 commits, one per task):

| Module | Role |
|--------|------|
| `vault/keyAccess` | `getVaultKeys()` → KEK + metadata key from key-storage |
| `items/itemBlob` | `[wrappedDek(97)][ciphertext]` codec |
| `items/metadata` | encrypt/decrypt `{name,contentType,size,contentId}` |
| `items/itemCrypto` | envelope encrypt/decrypt + `contentId` HMAC binding |
| `api/items` | upload init → S3 PUT → complete, list, download, delete |
| `components/FileUpload` | encrypt → upload, 100 MB guard |
| `components/FileList` | decrypt rows, download+decrypt, delete |
| `Dashboard` | wires upload + list, refresh-after-upload |

### Adapted to the #208 Smithy SDK
The original plan predated #208 (one Smithy contract → generated backend + frontend). This implementation targets the **generated `@cortex/client` SDK** instead of the old hand-rolled `fetch` client — which is also the root-cause fix for the earlier `feat/web-file-management` attempt that failed at runtime on camelCase/snake_case contract drift:
- `api/items.ts` sends generated commands (`InitiateItemUpload`/`CompleteItemUpload`/`ListItems`/`GetItemDownloadUrl`/`DeleteItem`) through an exported `makeClient()`. Only `putToS3` stays a raw `fetch` PUT (presigned URL isn't a Smithy op).
- `encryptedMetadata` is a `Blob` (`Uint8Array`) the SDK base64s on the wire — the metadata codec works in raw bytes (no manual base64 double-encode).
- `ItemData.createdAt` is a `Date` (not epoch seconds); `ItemData` reused from the SDK.

### Verification
- ✅ `vitest --run` — **17 files / 50 tests green** (from `packages/web`)
- ✅ `tsc --noEmit` — clean
- ✅ `npm run build:all` — client + encryption + web build

### Not in this PR (deferred)
- **Live smoke test vs real Cognito + backend** — unit tests confirm wiring against the generated types; a real presigned-S3 round-trip is still unrun.
- Files > 100 MB (Slice 2.5: streaming + multipart), thumbnails/progress/rename, collections/tags (Slice 3), key zeroization (6.16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)