### PR TITLE
feat(api): Phase B Slice 2.5b — contract + backend S3 multipart

### DIFF
--- a/lambda/src/api/routes/items.py
+++ b/lambda/src/api/routes/items.py
@@ -22,6 +22,7 @@ from src.api.services.vault_service import VaultService
 from src.shared.auth import get_current_user
 from src.shared.exceptions import BadRequestError, NotFoundError
 from src.shared.generated.models import (
+    CompleteItemUploadRequestContent,
     CompleteItemUploadResponseContent,
     CreateItemRequestContent,
     CreateItemResponseContent,
@@ -149,17 +150,22 @@ class CompleteUploadRoute(BaseRoute):
         )
         def handle(
             item_id: str,
+            request: CompleteItemUploadRequestContent | None = None,
             user_id: str = Depends(get_current_user),
         ):
             """
             Mark MEDIA upload complete, store metadata.
 
             Verifies the upload succeeded and flips the item from PENDING to
-            COMPLETE. The item id comes from the path (Smithy contract).
+            COMPLETE. The item id comes from the path (Smithy contract). The
+            body is optional: multipart uploads send uploadId + parts, single-PUT
+            uploads send no body.
 
             Requirements: 1.4, 2.2, 2.5, 24.2
             """
-            response = self.item_service.complete_upload(user_id=user_id, item_id=item_id)
+            response = self.item_service.complete_upload(
+                user_id=user_id, item_id=item_id, request=request
+            )
 
             logger.info(
                 "Upload completed successfully",

--- a/lambda/src/api/routes/items.py
+++ b/lambda/src/api/routes/items.py
@@ -25,6 +25,8 @@ from src.shared.generated.models import (
     CompleteItemUploadResponseContent,
     CreateItemRequestContent,
     CreateItemResponseContent,
+    CreateUploadPartUrlsRequestContent,
+    CreateUploadPartUrlsResponseContent,
     DeleteItemResponseContent,
     GetItemDownloadUrlResponseContent,
     GetItemResponseContent,
@@ -166,6 +168,26 @@ class CompleteUploadRoute(BaseRoute):
             )
 
             return response
+
+
+class CreateUploadPartUrlsRoute(BaseRoute):
+    """Mint presigned URLs for multipart upload parts."""
+
+    def __init__(self, item_service: ItemService):
+        self.item_service = item_service
+
+    def register(self, app: APIRouter) -> None:
+        @app.post(
+            "/v1/items/{item_id}/upload/parts",
+            response_model=CreateUploadPartUrlsResponseContent,
+        )
+        def handle(
+            item_id: str,
+            request: CreateUploadPartUrlsRequestContent,
+            user_id: str = Depends(get_current_user),
+        ):
+            """Mint a batch of presigned URLs for multipart upload parts."""
+            return self.item_service.create_upload_part_urls(user_id, item_id, request)
 
 
 class ListItemsRoute(BaseRoute):

--- a/lambda/src/api/routes/items.py
+++ b/lambda/src/api/routes/items.py
@@ -22,6 +22,8 @@ from src.api.services.vault_service import VaultService
 from src.shared.auth import get_current_user
 from src.shared.exceptions import BadRequestError, NotFoundError
 from src.shared.generated.models import (
+    AbortItemUploadRequestContent,
+    AbortItemUploadResponseContent,
     CompleteItemUploadRequestContent,
     CompleteItemUploadResponseContent,
     CreateItemRequestContent,
@@ -194,6 +196,26 @@ class CreateUploadPartUrlsRoute(BaseRoute):
         ):
             """Mint a batch of presigned URLs for multipart upload parts."""
             return self.item_service.create_upload_part_urls(user_id, item_id, request)
+
+
+class AbortItemUploadRoute(BaseRoute):
+    """Abort an in-progress multipart upload."""
+
+    def __init__(self, item_service: ItemService):
+        self.item_service = item_service
+
+    def register(self, app: APIRouter) -> None:
+        @app.post(
+            "/v1/items/{item_id}/upload/abort",
+            response_model=AbortItemUploadResponseContent,
+        )
+        def handle(
+            item_id: str,
+            request: AbortItemUploadRequestContent,
+            user_id: str = Depends(get_current_user),
+        ):
+            """Abort an in-progress multipart upload and delete the pending item."""
+            return self.item_service.abort_upload(user_id, item_id, request)
 
 
 class ListItemsRoute(BaseRoute):

--- a/lambda/src/api/services/item_service.py
+++ b/lambda/src/api/services/item_service.py
@@ -16,6 +16,7 @@ import boto3
 
 from src.shared.exceptions import BadRequestError, NotFoundError
 from src.shared.generated.models import (
+    CompleteItemUploadRequestContent,
     CompleteItemUploadResponseContent,
     CreateItemRequestContent,
     CreateItemResponseContent,
@@ -305,7 +306,12 @@ class ItemService:
         ]
         return CreateUploadPartUrlsResponseContent(urls=urls)
 
-    def complete_upload(self, user_id: str, item_id: str) -> CompleteItemUploadResponseContent:
+    def complete_upload(
+        self,
+        user_id: str,
+        item_id: str,
+        request: CompleteItemUploadRequestContent | None = None,
+    ) -> CompleteItemUploadResponseContent:
         """
         Mark MEDIA upload as complete and finalize metadata.
 
@@ -314,10 +320,14 @@ class ItemService:
         TOCTOU race conditions where S3 object could be deleted between
         verification and DynamoDB update.
 
+        For multipart uploads (request.parts present), the staged parts are
+        assembled into the final object before verification. Single-PUT uploads
+        (no request body / no parts) skip straight to verification.
+
         Args:
             item_id: Item ID to complete
             user_id: Authenticated user ID
-            request: Upload completion request
+            request: Upload completion request (multipart uploadId + parts; optional)
 
         Returns:
             Upload completion response
@@ -342,6 +352,17 @@ class ItemService:
         # Verify user owns the item
         if item["user_id"] != user_id:
             raise NotFoundError("Item not found")
+
+        # Multipart: assemble the staged parts into the final object before we
+        # verify it exists. Single-PUT uploads (no parts) skip straight to verify.
+        if request is not None and request.parts:
+            upload_id = request.upload_id or item.get("upload_id")
+            if not upload_id:
+                raise BadRequestError("Multipart completion requires an uploadId")
+            s3_parts = [
+                {"PartNumber": p.part_number, "ETag": p.e_tag} for p in request.parts
+            ]
+            self.s3_repo.complete_multipart_upload(item["s3_key"], upload_id, s3_parts)
 
         # Verify S3 object exists and get metadata (including version if available)
         s3_key = item["s3_key"]

--- a/lambda/src/api/services/item_service.py
+++ b/lambda/src/api/services/item_service.py
@@ -19,8 +19,11 @@ from src.shared.generated.models import (
     CompleteItemUploadResponseContent,
     CreateItemRequestContent,
     CreateItemResponseContent,
+    CreateUploadPartUrlsRequestContent,
+    CreateUploadPartUrlsResponseContent,
     InitiateItemUploadRequestContent,
     InitiateItemUploadResponseContent,
+    UploadPartUrl,
 )
 from src.shared.logger import get_logger
 from src.shared.models import ItemType, SearchByTagResponse
@@ -272,6 +275,35 @@ class ItemService:
             expires_at=int(expires_at.timestamp()),
             s3_key=s3_key,
         )
+
+    def create_upload_part_urls(
+        self, user_id: str, item_id: str, request: CreateUploadPartUrlsRequestContent
+    ) -> CreateUploadPartUrlsResponseContent:
+        """
+        Mint presigned URLs for a batch of multipart upload parts.
+
+        The client requests fresh batches as it uploads, so URLs never outlive
+        the 15-minute presign window during a long transfer.
+        """
+        item = self.items_repo.get_item({"PK": f"ITEM#{item_id}"})
+        if not item or item["user_id"] != user_id:
+            raise NotFoundError("Item not found")
+
+        s3_key = item["s3_key"]
+        expires_at = int(
+            (datetime.now(tz=timezone.utc) + timedelta(seconds=PRESIGNED_URL_EXPIRATION)).timestamp()
+        )
+        urls = [
+            UploadPartUrl(
+                part_number=n,
+                url=self.s3_repo.generate_multipart_upload_url(
+                    s3_key, UPLOAD_CONTENT_TYPE, n, request.upload_id, PRESIGNED_URL_EXPIRATION
+                ),
+                expires_at=expires_at,
+            )
+            for n in request.part_numbers
+        ]
+        return CreateUploadPartUrlsResponseContent(urls=urls)
 
     def complete_upload(self, user_id: str, item_id: str) -> CompleteItemUploadResponseContent:
         """

--- a/lambda/src/api/services/item_service.py
+++ b/lambda/src/api/services/item_service.py
@@ -16,6 +16,8 @@ import boto3
 
 from src.shared.exceptions import BadRequestError, NotFoundError
 from src.shared.generated.models import (
+    AbortItemUploadRequestContent,
+    AbortItemUploadResponseContent,
     CompleteItemUploadRequestContent,
     CompleteItemUploadResponseContent,
     CreateItemRequestContent,
@@ -305,6 +307,23 @@ class ItemService:
             for n in request.part_numbers
         ]
         return CreateUploadPartUrlsResponseContent(urls=urls)
+
+    def abort_upload(
+        self, user_id: str, item_id: str, request: AbortItemUploadRequestContent
+    ) -> AbortItemUploadResponseContent:
+        """Abort an in-progress multipart upload and delete the pending item."""
+        key = {"PK": f"ITEM#{item_id}"}
+        item = self.items_repo.get_item(key)
+        if not item or item["user_id"] != user_id:
+            raise NotFoundError("Item not found")
+
+        self.s3_repo.abort_multipart_upload(item["s3_key"], request.upload_id)
+        self.items_repo.delete_item(key)
+        logger.info(
+            "Aborted upload",
+            **{"user_id": user_id, "item_id": item_id, "upload_id": request.upload_id},
+        )
+        return AbortItemUploadResponseContent(message="Upload aborted")
 
     def complete_upload(
         self,

--- a/lambda/src/api/services/item_service.py
+++ b/lambda/src/api/services/item_service.py
@@ -270,13 +270,12 @@ class ItemService:
         # Store metadata
         self.items_repo.put_item(item)
 
-        # NOTE: upload_id (multipart) is stored on the item but not returned —
-        # the contract has no field for it (multipart isn't wired in the client).
         return InitiateItemUploadResponseContent(
             item_id=item_id,
             upload_url=upload_url,
             expires_at=int(expires_at.timestamp()),
             s3_key=s3_key,
+            upload_id=upload_id,
         )
 
     def create_upload_part_urls(
@@ -294,7 +293,9 @@ class ItemService:
 
         s3_key = item["s3_key"]
         expires_at = int(
-            (datetime.now(tz=timezone.utc) + timedelta(seconds=PRESIGNED_URL_EXPIRATION)).timestamp()
+            (
+                datetime.now(tz=timezone.utc) + timedelta(seconds=PRESIGNED_URL_EXPIRATION)
+            ).timestamp()
         )
         urls = [
             UploadPartUrl(
@@ -378,9 +379,7 @@ class ItemService:
             upload_id = request.upload_id or item.get("upload_id")
             if not upload_id:
                 raise BadRequestError("Multipart completion requires an uploadId")
-            s3_parts = [
-                {"PartNumber": p.part_number, "ETag": p.e_tag} for p in request.parts
-            ]
+            s3_parts = [{"PartNumber": p.part_number, "ETag": p.e_tag} for p in request.parts]
             self.s3_repo.complete_multipart_upload(item["s3_key"], upload_id, s3_parts)
 
         # Verify S3 object exists and get metadata (including version if available)

--- a/lambda/src/environment/service_provider.py
+++ b/lambda/src/environment/service_provider.py
@@ -32,6 +32,7 @@ from src.api.routes.collections import (
 from src.api.routes.items import (
     CompleteUploadRoute,
     CreateItemRoute,
+    CreateUploadPartUrlsRoute,
     DeleteItemRoute,
     DownloadItemRoute,
     GetItemRoute,
@@ -244,6 +245,7 @@ class ServiceProvider:
             CreateItemRoute(item_service=self.item_service),
             InitiateUploadRoute(item_service=self.item_service),
             CompleteUploadRoute(item_service=self.item_service),
+            CreateUploadPartUrlsRoute(item_service=self.item_service),
             ListItemsRoute(item_service=self.item_service, vault_service=self.vault_service),
             GetItemRoute(item_service=self.item_service, vault_service=self.vault_service),
             UpdateItemRoute(item_service=self.item_service),

--- a/lambda/src/environment/service_provider.py
+++ b/lambda/src/environment/service_provider.py
@@ -30,6 +30,7 @@ from src.api.routes.collections import (
     UpdateCollectionRoute,
 )
 from src.api.routes.items import (
+    AbortItemUploadRoute,
     CompleteUploadRoute,
     CreateItemRoute,
     CreateUploadPartUrlsRoute,
@@ -246,6 +247,7 @@ class ServiceProvider:
             InitiateUploadRoute(item_service=self.item_service),
             CompleteUploadRoute(item_service=self.item_service),
             CreateUploadPartUrlsRoute(item_service=self.item_service),
+            AbortItemUploadRoute(item_service=self.item_service),
             ListItemsRoute(item_service=self.item_service, vault_service=self.vault_service),
             GetItemRoute(item_service=self.item_service, vault_service=self.vault_service),
             UpdateItemRoute(item_service=self.item_service),

--- a/lambda/src/shared/generated/models.py
+++ b/lambda/src/shared/generated/models.py
@@ -11,6 +11,14 @@ from pydantic import Base64Bytes, Field
 from src.shared._codegen_base import GeneratedBaseModel
 
 
+class AbortItemUploadRequestContent(GeneratedBaseModel):
+    upload_id: Annotated[str, Field(alias="uploadId", description="Multipart upload id to abort")]
+
+
+class AbortItemUploadResponseContent(GeneratedBaseModel):
+    message: Annotated[str | None, Field(description="Confirmation message")] = None
+
+
 class AddItemToCollectionRequestContent(GeneratedBaseModel):
     item_id: Annotated[str, Field(alias="itemId", description="Item identifier to add")]
 
@@ -86,6 +94,15 @@ class CreateShareResponseContent(GeneratedBaseModel):
     ] = None
     is_password_protected: Annotated[
         bool, Field(alias="isPasswordProtected", description="Whether share is password protected")
+    ]
+
+
+class CreateUploadPartUrlsRequestContent(GeneratedBaseModel):
+    upload_id: Annotated[
+        str, Field(alias="uploadId", description="Multipart upload id from InitiateItemUpload")
+    ]
+    part_numbers: Annotated[
+        list[float], Field(alias="partNumbers", description="Part numbers to mint URLs for")
     ]
 
 
@@ -193,6 +210,13 @@ class InitiateItemUploadResponseContent(GeneratedBaseModel):
     s3_key: Annotated[
         str | None, Field(alias="s3Key", description="S3 key for the uploaded object")
     ] = None
+    upload_id: Annotated[
+        str | None,
+        Field(
+            alias="uploadId",
+            description="Multipart upload id (present only for files above the multipart threshold)",
+        ),
+    ] = None
 
 
 class InternalErrorResponseContent(GeneratedBaseModel):
@@ -285,6 +309,23 @@ class UpdateItemResponseContent(GeneratedBaseModel):
     version: Annotated[float, Field(description="New version number")]
 
 
+class UploadPart(GeneratedBaseModel):
+    part_number: Annotated[
+        float, Field(alias="partNumber", description="Part number (1-10000)", ge=1.0, le=10000.0)
+    ]
+    e_tag: Annotated[
+        str, Field(alias="eTag", description="S3 ETag returned when the part was uploaded")
+    ]
+
+
+class UploadPartUrl(GeneratedBaseModel):
+    part_number: Annotated[
+        float, Field(alias="partNumber", description="Part number this URL uploads")
+    ]
+    url: Annotated[str, Field(description="Presigned S3 URL for this part")]
+    expires_at: Annotated[float, Field(alias="expiresAt", description="URL expiration timestamp")]
+
+
 class ValidationErrorDetail(GeneratedBaseModel):
     field: Annotated[str, Field(description="Field name that failed validation")]
     message: Annotated[str, Field(description="Validation error message")]
@@ -295,6 +336,17 @@ class ValidationErrorResponseContent(GeneratedBaseModel):
     code: Annotated[str | None, Field(description="Error code for client handling")] = None
     errors: Annotated[
         list[ValidationErrorDetail] | None, Field(description="List of validation errors")
+    ] = None
+
+
+class CompleteItemUploadRequestContent(GeneratedBaseModel):
+    upload_id: Annotated[
+        str | None,
+        Field(alias="uploadId", description="Multipart upload id (omit for single-PUT uploads)"),
+    ] = None
+    parts: Annotated[
+        list[UploadPart] | None,
+        Field(description="Uploaded parts to assemble, in order (multipart only)"),
     ] = None
 
 
@@ -334,6 +386,12 @@ class CreateItemResponseContent(GeneratedBaseModel):
     item_type: Annotated[ItemType, Field(alias="itemType")]
     created_at: Annotated[float, Field(alias="createdAt", description="Creation timestamp")]
     version: Annotated[float, Field(description="Version number for conflict resolution")]
+
+
+class CreateUploadPartUrlsResponseContent(GeneratedBaseModel):
+    urls: Annotated[
+        list[UploadPartUrl], Field(description="Presigned URLs, one per requested part number")
+    ]
 
 
 class GetItemResponseContent(GeneratedBaseModel):

--- a/lambda/src/shared/generated/models.py
+++ b/lambda/src/shared/generated/models.py
@@ -45,7 +45,7 @@ class CollectionData(GeneratedBaseModel):
         Base64Bytes, Field(alias="encryptedMetadata", description="Encrypted collection metadata")
     ]
     item_count: Annotated[
-        float, Field(alias="itemCount", description="Number of items in collection")
+        int, Field(alias="itemCount", description="Number of items in collection")
     ]
     created_at: Annotated[float, Field(alias="createdAt", description="Creation timestamp")]
     updated_at: Annotated[float, Field(alias="updatedAt", description="Last modified timestamp")]
@@ -102,7 +102,7 @@ class CreateUploadPartUrlsRequestContent(GeneratedBaseModel):
         str, Field(alias="uploadId", description="Multipart upload id from InitiateItemUpload")
     ]
     part_numbers: Annotated[
-        list[float], Field(alias="partNumbers", description="Part numbers to mint URLs for")
+        list[int], Field(alias="partNumbers", description="Part numbers to mint URLs for")
     ]
 
 
@@ -193,7 +193,7 @@ class InitiateItemUploadRequestContent(GeneratedBaseModel):
         Base64Bytes, Field(alias="encryptedMetadata", description="Encrypted metadata")
     ]
     size_bytes: Annotated[
-        float, Field(alias="sizeBytes", description="File size in bytes (for MEDIA items)", ge=1.0)
+        int, Field(alias="sizeBytes", description="File size in bytes (for MEDIA items)", ge=1)
     ]
     encrypted_tags: Annotated[
         list[Base64Bytes] | None,
@@ -298,7 +298,7 @@ class UpdateItemRequestContent(GeneratedBaseModel):
         str | None, Field(alias="timeBucket", description="Updated time bucket")
     ] = None
     expected_version: Annotated[
-        float | None,
+        int | None,
         Field(alias="expectedVersion", description="Expected version for optimistic locking"),
     ] = None
 
@@ -306,12 +306,12 @@ class UpdateItemRequestContent(GeneratedBaseModel):
 class UpdateItemResponseContent(GeneratedBaseModel):
     item_id: Annotated[str, Field(alias="itemId", description="Item identifier")]
     updated_at: Annotated[float, Field(alias="updatedAt", description="Update timestamp")]
-    version: Annotated[float, Field(description="New version number")]
+    version: Annotated[int, Field(description="New version number")]
 
 
 class UploadPart(GeneratedBaseModel):
     part_number: Annotated[
-        float, Field(alias="partNumber", description="Part number (1-10000)", ge=1.0, le=10000.0)
+        int, Field(alias="partNumber", description="Part number (1-10000)", ge=1, le=10000)
     ]
     e_tag: Annotated[
         str, Field(alias="eTag", description="S3 ETag returned when the part was uploaded")
@@ -320,7 +320,7 @@ class UploadPart(GeneratedBaseModel):
 
 class UploadPartUrl(GeneratedBaseModel):
     part_number: Annotated[
-        float, Field(alias="partNumber", description="Part number this URL uploads")
+        int, Field(alias="partNumber", description="Part number this URL uploads")
     ]
     url: Annotated[str, Field(description="Presigned S3 URL for this part")]
     expires_at: Annotated[float, Field(alias="expiresAt", description="URL expiration timestamp")]
@@ -385,7 +385,7 @@ class CreateItemResponseContent(GeneratedBaseModel):
     item_id: Annotated[str, Field(alias="itemId", description="Item identifier")]
     item_type: Annotated[ItemType, Field(alias="itemType")]
     created_at: Annotated[float, Field(alias="createdAt", description="Creation timestamp")]
-    version: Annotated[float, Field(description="Version number for conflict resolution")]
+    version: Annotated[int, Field(description="Version number for conflict resolution")]
 
 
 class CreateUploadPartUrlsResponseContent(GeneratedBaseModel):
@@ -421,14 +421,14 @@ class GetItemResponseContent(GeneratedBaseModel):
         Field(alias="timeBucket", description="Plaintext time bucket (for tasks/events)"),
     ] = None
     size_bytes: Annotated[
-        float | None, Field(alias="sizeBytes", description="File size in bytes (for MEDIA items)")
+        int | None, Field(alias="sizeBytes", description="File size in bytes (for MEDIA items)")
     ] = None
     s3_key: Annotated[str | None, Field(alias="s3Key", description="S3 key (for MEDIA items)")] = (
         None
     )
     created_at: Annotated[float, Field(alias="createdAt", description="Creation timestamp")]
     updated_at: Annotated[float, Field(alias="updatedAt", description="Last modified timestamp")]
-    version: Annotated[float, Field(description="Version number for conflict resolution")]
+    version: Annotated[int, Field(description="Version number for conflict resolution")]
 
 
 class ItemData(GeneratedBaseModel):
@@ -458,14 +458,14 @@ class ItemData(GeneratedBaseModel):
         Field(alias="timeBucket", description="Plaintext time bucket (for tasks/events)"),
     ] = None
     size_bytes: Annotated[
-        float | None, Field(alias="sizeBytes", description="File size in bytes (for MEDIA items)")
+        int | None, Field(alias="sizeBytes", description="File size in bytes (for MEDIA items)")
     ] = None
     s3_key: Annotated[str | None, Field(alias="s3Key", description="S3 key (for MEDIA items)")] = (
         None
     )
     created_at: Annotated[float, Field(alias="createdAt", description="Creation timestamp")]
     updated_at: Annotated[float, Field(alias="updatedAt", description="Last modified timestamp")]
-    version: Annotated[float, Field(description="Version number for conflict resolution")]
+    version: Annotated[int, Field(description="Version number for conflict resolution")]
 
 
 class ListItemsResponseContent(GeneratedBaseModel):
@@ -474,7 +474,7 @@ class ListItemsResponseContent(GeneratedBaseModel):
         str | None, Field(alias="nextToken", description="Token for next page of results")
     ] = None
     total_count: Annotated[
-        float, Field(alias="totalCount", description="Total count of items (may be approximate)")
+        int, Field(alias="totalCount", description="Total count of items (may be approximate)")
     ]
 
 
@@ -484,7 +484,7 @@ class SearchByTagResponseContent(GeneratedBaseModel):
         str | None, Field(alias="nextToken", description="Token for next page of results")
     ] = None
     total_count: Annotated[
-        float, Field(alias="totalCount", description="Total count of matching items")
+        int, Field(alias="totalCount", description="Total count of matching items")
     ]
 
 
@@ -495,7 +495,7 @@ class GetCollectionResponseContent(GeneratedBaseModel):
         Base64Bytes, Field(alias="encryptedMetadata", description="Encrypted collection metadata")
     ]
     item_count: Annotated[
-        float, Field(alias="itemCount", description="Number of items in collection")
+        int, Field(alias="itemCount", description="Number of items in collection")
     ]
     created_at: Annotated[float, Field(alias="createdAt", description="Creation timestamp")]
     updated_at: Annotated[float, Field(alias="updatedAt", description="Last modified timestamp")]

--- a/lambda/src/shared/repository.py
+++ b/lambda/src/shared/repository.py
@@ -557,6 +557,43 @@ class S3Repository:
             )
             raise
 
+    def complete_multipart_upload(
+        self, object_key: str, upload_id: str, parts: list[dict]
+    ) -> None:
+        """
+        Complete a multipart upload, assembling the staged parts into one object.
+
+        Args:
+            object_key: S3 object key
+            upload_id: Multipart upload ID
+            parts: Ordered list of {"PartNumber": int, "ETag": str}
+
+        Raises:
+            ClientError: If S3 rejects the completion (e.g. missing/mismatched parts)
+        """
+        try:
+            self._client.complete_multipart_upload(
+                Bucket=self.bucket_name,
+                Key=object_key,
+                UploadId=upload_id,
+                MultipartUpload={"Parts": parts},
+            )
+            logger.info(
+                "Completed multipart upload",
+                **{"object_key": object_key, "upload_id": upload_id, "part_count": len(parts)},
+            )
+        except ClientError as e:
+            logger.error(
+                "Failed to complete multipart upload",
+                **{
+                    "error": str(e),
+                    "bucket": self.bucket_name,
+                    "key": object_key,
+                    "upload_id": upload_id,
+                },
+            )
+            raise
+
     def delete_object(self, object_key: str) -> None:
         """
         Delete object from S3.

--- a/lambda/src/shared/repository.py
+++ b/lambda/src/shared/repository.py
@@ -557,9 +557,7 @@ class S3Repository:
             )
             raise
 
-    def complete_multipart_upload(
-        self, object_key: str, upload_id: str, parts: list[dict]
-    ) -> None:
+    def complete_multipart_upload(self, object_key: str, upload_id: str, parts: list[dict]) -> None:
         """
         Complete a multipart upload, assembling the staged parts into one object.
 

--- a/lambda/tests/unit/services/test_item_service.py
+++ b/lambda/tests/unit/services/test_item_service.py
@@ -957,7 +957,9 @@ class TestCompleteMultipartUpload:
         )
         # then the existing verify (head_object) + status flip
         s3_stubber.add_response(
-            "head_object", {"ContentLength": 10}, {"Bucket": files_bucket_name, "Key": "vault-1/item-1"}
+            "head_object",
+            {"ContentLength": 10},
+            {"Bucket": files_bucket_name, "Key": "vault-1/item-1"},
         )
         dynamodb_stubber.add_response(
             "update_item",
@@ -990,7 +992,9 @@ class TestCompleteMultipartUpload:
             {"Key": ANY, "TableName": ANY},
         )
         s3_stubber.add_response(
-            "head_object", {"ContentLength": 10}, {"Bucket": files_bucket_name, "Key": "vault-1/item-2"}
+            "head_object",
+            {"ContentLength": 10},
+            {"Bucket": files_bucket_name, "Key": "vault-1/item-2"},
         )
         dynamodb_stubber.add_response(
             "update_item",
@@ -1037,9 +1041,7 @@ class TestAbortUpload:
             {},
             {"Bucket": files_bucket_name, "Key": "vault-1/item-1", "UploadId": "u1"},
         )
-        dynamodb_stubber.add_response(
-            "delete_item", {}, {"TableName": ANY, "Key": ANY}
-        )
+        dynamodb_stubber.add_response("delete_item", {}, {"TableName": ANY, "Key": ANY})
 
         resp = item_service.abort_upload(
             "user-123", "item-1", AbortItemUploadRequestContent(upload_id="u1")
@@ -1060,3 +1062,39 @@ class TestAbortUpload:
             item_service.abort_upload(
                 "user-123", "item-1", AbortItemUploadRequestContent(upload_id="u1")
             )
+
+
+class TestInitiateReturnsUploadId:
+    def test_multipart_returns_upload_id(
+        self, item_service, dynamodb_stubber, s3_stubber, files_bucket_name
+    ):
+        # > 100 MB triggers multipart
+        s3_stubber.add_response(
+            "create_multipart_upload",
+            {"UploadId": "mp-123", "Bucket": files_bucket_name, "Key": "vaults/vault-1/files/x/y"},
+            {
+                "Bucket": files_bucket_name,
+                "Key": ANY,
+                "ContentType": ANY,
+                "ServerSideEncryption": "AES256",
+            },
+        )
+        dynamodb_stubber.add_response("put_item", {}, {"Item": ANY, "TableName": ANY})
+
+        req = InitiateItemUploadRequestContent(
+            vault_id="vault-1",
+            encrypted_metadata=base64.b64encode(b"m"),
+            size_bytes=200 * 1024 * 1024,
+        )
+        resp = item_service.initiate_upload("user-123", req)
+        assert resp.upload_id == "mp-123"
+
+    def test_single_put_has_no_upload_id(
+        self, item_service, dynamodb_stubber, s3_stubber, files_bucket_name
+    ):
+        dynamodb_stubber.add_response("put_item", {}, {"Item": ANY, "TableName": ANY})
+        req = InitiateItemUploadRequestContent(
+            vault_id="vault-1", encrypted_metadata=base64.b64encode(b"m"), size_bytes=1024
+        )
+        resp = item_service.initiate_upload("user-123", req)
+        assert resp.upload_id is None

--- a/lambda/tests/unit/services/test_item_service.py
+++ b/lambda/tests/unit/services/test_item_service.py
@@ -916,3 +916,94 @@ class TestCreateUploadPartUrls:
         req = CreateUploadPartUrlsRequestContent(upload_id="u1", part_numbers=[1])
         with pytest.raises(NotFoundError):
             item_service.create_upload_part_urls("user-123", "item-1", req)
+
+
+class TestCompleteMultipartUpload:
+    """complete_upload assembles multipart parts before verifying the object."""
+
+    def _pending(self, item_id, user_id="user-123"):
+        return {
+            "PK": f"ITEM#{item_id}",
+            "SK": "METADATA",
+            "item_id": item_id,
+            "user_id": user_id,
+            "vault_id": "vault-1",
+            "s3_key": f"vault-1/{item_id}",
+            "upload_id": "u1",
+            "upload_status": "PENDING",
+        }
+
+    def test_assembles_parts_then_completes(
+        self, item_service, dynamodb_stubber, s3_stubber, files_bucket_name
+    ):
+        from src.shared.generated.models import CompleteItemUploadRequestContent, UploadPart
+
+        item = self._pending("item-1")
+        dynamodb_stubber.add_response(
+            "get_item",
+            {"Item": {k: {"S": str(v)} for k, v in item.items()}},
+            {"Key": ANY, "TableName": ANY},
+        )
+        # multipart assembly happens first
+        s3_stubber.add_response(
+            "complete_multipart_upload",
+            {"Bucket": files_bucket_name, "Key": "vault-1/item-1", "ETag": '"final"'},
+            {
+                "Bucket": files_bucket_name,
+                "Key": "vault-1/item-1",
+                "UploadId": "u1",
+                "MultipartUpload": {"Parts": [{"PartNumber": 1, "ETag": '"e1"'}]},
+            },
+        )
+        # then the existing verify (head_object) + status flip
+        s3_stubber.add_response(
+            "head_object", {"ContentLength": 10}, {"Bucket": files_bucket_name, "Key": "vault-1/item-1"}
+        )
+        dynamodb_stubber.add_response(
+            "update_item",
+            {"Attributes": {}},
+            {
+                "Key": ANY,
+                "TableName": ANY,
+                "UpdateExpression": ANY,
+                "ConditionExpression": ANY,
+                "ExpressionAttributeNames": ANY,
+                "ExpressionAttributeValues": ANY,
+                "ReturnValues": "ALL_NEW",
+            },
+        )
+
+        req = CompleteItemUploadRequestContent(
+            upload_id="u1", parts=[UploadPart(part_number=1, e_tag='"e1"')]
+        )
+        resp = item_service.complete_upload("user-123", "item-1", req)
+        assert resp.item_id == "item-1"
+        s3_stubber.assert_no_pending_responses()
+
+    def test_single_put_path_unchanged_when_no_parts(
+        self, item_service, dynamodb_stubber, s3_stubber, files_bucket_name
+    ):
+        item = self._pending("item-2")
+        dynamodb_stubber.add_response(
+            "get_item",
+            {"Item": {k: {"S": str(v)} for k, v in item.items()}},
+            {"Key": ANY, "TableName": ANY},
+        )
+        s3_stubber.add_response(
+            "head_object", {"ContentLength": 10}, {"Bucket": files_bucket_name, "Key": "vault-1/item-2"}
+        )
+        dynamodb_stubber.add_response(
+            "update_item",
+            {"Attributes": {}},
+            {
+                "Key": ANY,
+                "TableName": ANY,
+                "UpdateExpression": ANY,
+                "ConditionExpression": ANY,
+                "ExpressionAttributeNames": ANY,
+                "ExpressionAttributeValues": ANY,
+                "ReturnValues": "ALL_NEW",
+            },
+        )
+        resp = item_service.complete_upload("user-123", "item-2", None)  # no body → single-PUT
+        assert resp.item_id == "item-2"

--- a/lambda/tests/unit/services/test_item_service.py
+++ b/lambda/tests/unit/services/test_item_service.py
@@ -1007,3 +1007,56 @@ class TestCompleteMultipartUpload:
         )
         resp = item_service.complete_upload("user-123", "item-2", None)  # no body → single-PUT
         assert resp.item_id == "item-2"
+
+
+class TestAbortUpload:
+    def _pending(self, item_id, user_id="user-123"):
+        return {
+            "PK": f"ITEM#{item_id}",
+            "SK": "METADATA",
+            "item_id": item_id,
+            "user_id": user_id,
+            "vault_id": "vault-1",
+            "s3_key": f"vault-1/{item_id}",
+            "upload_id": "u1",
+        }
+
+    def test_aborts_and_deletes_pending_item(
+        self, item_service, dynamodb_stubber, s3_stubber, files_bucket_name
+    ):
+        from src.shared.generated.models import AbortItemUploadRequestContent
+
+        item = self._pending("item-1")
+        dynamodb_stubber.add_response(
+            "get_item",
+            {"Item": {k: {"S": str(v)} for k, v in item.items()}},
+            {"Key": ANY, "TableName": ANY},
+        )
+        s3_stubber.add_response(
+            "abort_multipart_upload",
+            {},
+            {"Bucket": files_bucket_name, "Key": "vault-1/item-1", "UploadId": "u1"},
+        )
+        dynamodb_stubber.add_response(
+            "delete_item", {}, {"TableName": ANY, "Key": ANY}
+        )
+
+        resp = item_service.abort_upload(
+            "user-123", "item-1", AbortItemUploadRequestContent(upload_id="u1")
+        )
+        assert resp.message
+        s3_stubber.assert_no_pending_responses()
+
+    def test_rejects_foreign_item(self, item_service, dynamodb_stubber):
+        from src.shared.generated.models import AbortItemUploadRequestContent
+
+        item = self._pending("item-1", user_id="someone-else")
+        dynamodb_stubber.add_response(
+            "get_item",
+            {"Item": {k: {"S": str(v)} for k, v in item.items()}},
+            {"Key": ANY, "TableName": ANY},
+        )
+        with pytest.raises(NotFoundError):
+            item_service.abort_upload(
+                "user-123", "item-1", AbortItemUploadRequestContent(upload_id="u1")
+            )

--- a/lambda/tests/unit/services/test_item_service.py
+++ b/lambda/tests/unit/services/test_item_service.py
@@ -871,3 +871,48 @@ class TestDeleteItem:
         )
 
         item_service.delete_item("user-123", "item-1")
+
+
+class TestCreateUploadPartUrls:
+    """Tests for create_upload_part_urls (multipart part-URL minting)."""
+
+    def _pending_media_item(self, item_id, user_id="user-123"):
+        return {
+            "PK": f"ITEM#{item_id}",
+            "SK": "METADATA",
+            "item_id": item_id,
+            "user_id": user_id,
+            "vault_id": "vault-1",
+            "s3_key": f"vault-1/{item_id}",
+            "upload_id": "u1",
+            "upload_status": "PENDING",
+        }
+
+    def test_mints_urls_for_requested_parts(self, item_service, dynamodb_stubber):
+        from src.shared.generated.models import CreateUploadPartUrlsRequestContent
+
+        item = self._pending_media_item("item-1")
+        dynamodb_stubber.add_response(
+            "get_item",
+            {"Item": {k: {"S": str(v)} for k, v in item.items()}},
+            {"Key": ANY, "TableName": ANY},
+        )
+
+        req = CreateUploadPartUrlsRequestContent(upload_id="u1", part_numbers=[1, 2, 3])
+        resp = item_service.create_upload_part_urls("user-123", "item-1", req)
+
+        assert [u.part_number for u in resp.urls] == [1, 2, 3]
+        assert all(u.url for u in resp.urls)
+
+    def test_rejects_when_user_does_not_own_item(self, item_service, dynamodb_stubber):
+        from src.shared.generated.models import CreateUploadPartUrlsRequestContent
+
+        item = self._pending_media_item("item-1", user_id="someone-else")
+        dynamodb_stubber.add_response(
+            "get_item",
+            {"Item": {k: {"S": str(v)} for k, v in item.items()}},
+            {"Key": ANY, "TableName": ANY},
+        )
+        req = CreateUploadPartUrlsRequestContent(upload_id="u1", part_numbers=[1])
+        with pytest.raises(NotFoundError):
+            item_service.create_upload_part_urls("user-123", "item-1", req)

--- a/lambda/tests/unit/services/test_repository_multipart.py
+++ b/lambda/tests/unit/services/test_repository_multipart.py
@@ -1,0 +1,39 @@
+"""Unit tests for S3Repository multipart completion (botocore Stubber, not moto)."""
+
+import pytest
+
+from src.shared.repository import S3Repository
+
+
+@pytest.fixture
+def s3_repo(boto_session, files_bucket_name):
+    return S3Repository(boto_session, files_bucket_name)
+
+
+class TestCompleteMultipartUpload:
+    def test_completes_with_ordered_parts(self, s3_repo, s3_stubber, files_bucket_name):
+        s3_stubber.add_response(
+            "complete_multipart_upload",
+            {"Bucket": files_bucket_name, "Key": "vault/item", "ETag": '"final-etag"'},
+            {
+                "Bucket": files_bucket_name,
+                "Key": "vault/item",
+                "UploadId": "u1",
+                "MultipartUpload": {
+                    "Parts": [
+                        {"PartNumber": 1, "ETag": '"e1"'},
+                        {"PartNumber": 2, "ETag": '"e2"'},
+                    ]
+                },
+            },
+        )
+
+        s3_repo.complete_multipart_upload(
+            "vault/item", "u1", [{"PartNumber": 1, "ETag": '"e1"'}, {"PartNumber": 2, "ETag": '"e2"'}]
+        )
+        s3_stubber.assert_no_pending_responses()
+
+    def test_raises_on_s3_error(self, s3_repo, s3_stubber):
+        s3_stubber.add_client_error("complete_multipart_upload", service_error_code="NoSuchUpload")
+        with pytest.raises(Exception):
+            s3_repo.complete_multipart_upload("vault/item", "bad", [{"PartNumber": 1, "ETag": '"e1"'}])

--- a/lambda/tests/unit/services/test_repository_multipart.py
+++ b/lambda/tests/unit/services/test_repository_multipart.py
@@ -29,11 +29,15 @@ class TestCompleteMultipartUpload:
         )
 
         s3_repo.complete_multipart_upload(
-            "vault/item", "u1", [{"PartNumber": 1, "ETag": '"e1"'}, {"PartNumber": 2, "ETag": '"e2"'}]
+            "vault/item",
+            "u1",
+            [{"PartNumber": 1, "ETag": '"e1"'}, {"PartNumber": 2, "ETag": '"e2"'}],
         )
         s3_stubber.assert_no_pending_responses()
 
     def test_raises_on_s3_error(self, s3_repo, s3_stubber):
         s3_stubber.add_client_error("complete_multipart_upload", service_error_code="NoSuchUpload")
         with pytest.raises(Exception):
-            s3_repo.complete_multipart_upload("vault/item", "bad", [{"PartNumber": 1, "ETag": '"e1"'}])
+            s3_repo.complete_multipart_upload(
+                "vault/item", "bad", [{"PartNumber": 1, "ETag": '"e1"'}]
+            )

--- a/smithy/models/item/item.smithy
+++ b/smithy/models/item/item.smithy
@@ -21,6 +21,8 @@ resource Item {
     operations: [
         CompleteItemUpload
         GetItemDownloadUrl
+        CreateUploadPartUrls
+        AbortItemUpload
     ]
 }
 
@@ -220,6 +222,9 @@ structure InitiateItemUploadOutput {
 
     @documentation("S3 key for the uploaded object")
     s3Key: String
+
+    @documentation("Multipart upload id (present only for files above the multipart threshold)")
+    uploadId: String
 }
 
 structure CompleteItemUploadInput {
@@ -227,6 +232,12 @@ structure CompleteItemUploadInput {
     @httpLabel
     @documentation("Item identifier (must be MEDIA type)")
     itemId: String
+
+    @documentation("Multipart upload id (omit for single-PUT uploads)")
+    uploadId: String
+
+    @documentation("Uploaded parts to assemble, in order (multipart only)")
+    parts: UploadPartList
 }
 
 structure CompleteItemUploadOutput {
@@ -406,4 +417,111 @@ structure DeleteItemOutput {
     @required
     @documentation("Deletion timestamp")
     deletedAt: Timestamp
+}
+
+// ============================================================================
+// Multipart upload (large-file streaming, slice 2.5b)
+// ============================================================================
+@documentation("An uploaded multipart part and its S3 ETag")
+structure UploadPart {
+    @required
+    @documentation("Part number (1-10000)")
+    @range(min: 1, max: 10000)
+    partNumber: Integer
+
+    @required
+    @documentation("S3 ETag returned when the part was uploaded")
+    eTag: String
+}
+
+list UploadPartList {
+    member: UploadPart
+}
+
+list PartNumberList {
+    member: Integer
+}
+
+@documentation("A presigned URL for uploading one multipart part")
+structure UploadPartUrl {
+    @required
+    @documentation("Part number this URL uploads")
+    partNumber: Integer
+
+    @required
+    @documentation("Presigned S3 URL for this part")
+    url: String
+
+    @required
+    @documentation("URL expiration timestamp")
+    expiresAt: Timestamp
+}
+
+list UploadPartUrlList {
+    member: UploadPartUrl
+}
+
+@http(method: "POST", uri: "/v1/items/{itemId}/upload/parts")
+@documentation("Mint a batch of presigned URLs for multipart upload parts")
+operation CreateUploadPartUrls {
+    input: CreateUploadPartUrlsInput
+    output: CreateUploadPartUrlsOutput
+    errors: [
+        AuthenticationError
+        AuthorizationError
+        ResourceNotFoundError
+        ValidationError
+        InternalError
+    ]
+}
+
+structure CreateUploadPartUrlsInput {
+    @required
+    @httpLabel
+    @documentation("Item identifier (must be a pending MEDIA upload)")
+    itemId: String
+
+    @required
+    @documentation("Multipart upload id from InitiateItemUpload")
+    uploadId: String
+
+    @required
+    @documentation("Part numbers to mint URLs for")
+    partNumbers: PartNumberList
+}
+
+structure CreateUploadPartUrlsOutput {
+    @required
+    @documentation("Presigned URLs, one per requested part number")
+    urls: UploadPartUrlList
+}
+
+@http(method: "POST", uri: "/v1/items/{itemId}/upload/abort")
+@documentation("Abort an in-progress multipart upload and clean up the pending item")
+operation AbortItemUpload {
+    input: AbortItemUploadInput
+    output: AbortItemUploadOutput
+    errors: [
+        AuthenticationError
+        AuthorizationError
+        ResourceNotFoundError
+        ValidationError
+        InternalError
+    ]
+}
+
+structure AbortItemUploadInput {
+    @required
+    @httpLabel
+    @documentation("Item identifier")
+    itemId: String
+
+    @required
+    @documentation("Multipart upload id to abort")
+    uploadId: String
+}
+
+structure AbortItemUploadOutput {
+    @documentation("Confirmation message")
+    message: String
 }

--- a/smithy/smithy-build.json
+++ b/smithy/smithy-build.json
@@ -12,7 +12,8 @@
           "protocol": "aws.protocols#restJson1",
           "version": "3.0.2",
           "apiGatewayType": "REST",
-          "disableCloudFormationSubstitution": true
+          "disableCloudFormationSubstitution": true,
+          "useIntegerType": true
         }
       }
     },


### PR DESCRIPTION
## Phase B · Slice 2.5b — Contract + backend multipart

Makes S3 multipart uploads reachable end-to-end so the web client (2.5c) can upload files >100 MB. Backend-only; the single-PUT path (files ≤ 100 MB threshold) is unchanged.

### Contract (Smithy → regenerated Python models + `@cortex/client`)
- `InitiateItemUploadOutput`: add optional `uploadId` (present above the multipart threshold).
- New op **`CreateUploadPartUrls`** `POST /v1/items/{itemId}/upload/parts` — mints a batch of presigned part URLs (lazy/batched).
- `CompleteItemUploadInput`: add optional `uploadId` + `parts[]`.
- New op **`AbortItemUpload`** `POST /v1/items/{itemId}/upload/abort`.
- Set OpenAPI `useIntegerType: true` so Smithy `Integer` maps to Python `int` (was `float`, which broke boto3 `PartNumber`). Regenerated all models — full suite green.

### Backend
- `S3Repository.complete_multipart_upload(key, upload_id, parts)`.
- `ItemService.create_upload_part_urls` / multipart-aware `complete_upload` (assembles parts before S3 verify; **single-PUT path unchanged**) / `abort_upload`; `initiate_upload` now returns `uploadId` for multipart.
- Two new routes registered in `service_provider.py`. `complete_upload` route body is **optional** so existing no-body single-PUT completes still work (no 422).

### CDK
- No change: the files bucket already has `abortIncompleteMultipartUploadAfter: Duration.days(7)` (the design's orphan-cleanup backstop). `tsc` green.

### Verification
- Backend: **277 passed**, coverage 85.65% (gate 80%).
- `@cortex/client` builds clean; `CreateUploadPartUrlsCommand` + `AbortItemUploadCommand` present.
- `build:all` green (web compiles against regenerated contract); encryption 216 passed; web 50 passed.

### Notes / out of scope
- TS client (`packages/client/`) is gitignored/regenerated; not committed (Python models are).
- Skipped a net-new CDK jest test (no test harness exists in `cdk/`; repo verifies via synth; rule already present).
- Next: 2.5c (streaming upload) + 2.5d (streaming download) consume these ops. Live Cognito/S3 smoke still unrun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)