### PR TITLE
feat(web): Phase B Slice 2.5c — streaming chunked upload (single-PUT + multipart)

### DIFF
--- a/packages/web/src/api/items.test.ts
+++ b/packages/web/src/api/items.test.ts
@@ -28,13 +28,28 @@ vi.mock('@cortex/client', () => ({
   DeleteItemCommand: class {
     constructor(public input: unknown) { commands.push(['DeleteItem', input]); }
   },
+  CreateUploadPartUrlsCommand: class {
+    constructor(public input: unknown) { commands.push(['CreateUploadPartUrls', input]); }
+  },
+  AbortItemUploadCommand: class {
+    constructor(public input: unknown) { commands.push(['AbortItemUpload', input]); }
+  },
 }));
 vi.mock('aws-amplify/auth', () => ({
   fetchAuthSession: vi.fn(async () => ({ tokens: { idToken: { toString: () => 'JWT' } } })),
 }));
 vi.mock('../config', () => ({ getConfig: () => ({ apiBaseUrl: 'https://api' }) }));
 
-import { initiateUpload, putToS3, completeUpload, listItems, getDownloadUrl, deleteItem } from './items';
+import {
+  initiateUpload,
+  putToS3,
+  completeUpload,
+  createUploadPartUrls,
+  abortUpload,
+  listItems,
+  getDownloadUrl,
+  deleteItem,
+} from './items';
 
 beforeEach(() => {
   sendMock.mockReset();
@@ -51,11 +66,12 @@ describe('items api', () => {
     expect(commands).toContainEqual(['InitiateItemUpload', { vaultId: 'v1', encryptedMetadata: meta, sizeBytes: 200 }]);
   });
 
-  it('putToS3 PUTs raw bytes with NO Authorization header', async () => {
-    const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+  it('putToS3 PUTs raw bytes with NO Authorization header and returns the ETag', async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 200, headers: { ETag: '"abc"' } }));
     vi.stubGlobal('fetch', fetchMock);
     const blob = new Uint8Array([1, 2, 3]);
-    await putToS3('https://s3/put', blob);
+    const eTag = await putToS3('https://s3/put', blob);
+    expect(eTag).toBe('"abc"');
     const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
     expect(url).toBe('https://s3/put');
     expect(init.method).toBe('PUT');
@@ -68,10 +84,48 @@ describe('items api', () => {
     await expect(putToS3('https://s3/put', new Uint8Array([1]))).rejects.toThrow('403');
   });
 
-  it('completeUpload sends the command with the itemId', async () => {
+  it('putToS3 throws when the ETag header is missing (CORS not exposing it)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(null, { status: 200 })));
+    await expect(putToS3('https://s3/put', new Uint8Array([1]))).rejects.toThrow(/ETag/);
+  });
+
+  it('initiateUpload surfaces uploadId when the server sends one (multipart)', async () => {
+    sendMock.mockResolvedValueOnce({ itemId: 'i1', uploadUrl: 'https://s3/put', uploadId: 'mp1' });
+    const out = await initiateUpload({ vaultId: 'v1', encryptedMetadata: new Uint8Array([1]), sizeBytes: 999 });
+    expect(out).toEqual({ itemId: 'i1', uploadUrl: 'https://s3/put', uploadId: 'mp1' });
+  });
+
+  it('createUploadPartUrls maps the response to {partNumber, url}', async () => {
+    sendMock.mockResolvedValueOnce({
+      urls: [
+        { partNumber: 1, url: 'https://s3/p1', expiresAt: new Date(0) },
+        { partNumber: 2, url: 'https://s3/p2', expiresAt: new Date(0) },
+      ],
+    });
+    const urls = await createUploadPartUrls('i1', 'mp1', [1, 2]);
+    expect(urls).toEqual([{ partNumber: 1, url: 'https://s3/p1' }, { partNumber: 2, url: 'https://s3/p2' }]);
+    expect(commands).toContainEqual(['CreateUploadPartUrls', { itemId: 'i1', uploadId: 'mp1', partNumbers: [1, 2] }]);
+  });
+
+  it('completeUpload sends only the itemId for single-PUT', async () => {
     sendMock.mockResolvedValueOnce({ itemId: 'i1', completedAt: new Date(0) });
     await completeUpload('i1');
     expect(commands).toContainEqual(['CompleteItemUpload', { itemId: 'i1' }]);
+  });
+
+  it('completeUpload passes uploadId + parts for multipart', async () => {
+    sendMock.mockResolvedValueOnce({ itemId: 'i1', completedAt: new Date(0) });
+    await completeUpload('i1', { uploadId: 'mp1', parts: [{ partNumber: 1, eTag: '"e1"' }] });
+    expect(commands).toContainEqual([
+      'CompleteItemUpload',
+      { itemId: 'i1', uploadId: 'mp1', parts: [{ partNumber: 1, eTag: '"e1"' }] },
+    ]);
+  });
+
+  it('abortUpload sends itemId + uploadId', async () => {
+    sendMock.mockResolvedValueOnce({ message: 'Upload aborted' });
+    await abortUpload('i1', 'mp1');
+    expect(commands).toContainEqual(['AbortItemUpload', { itemId: 'i1', uploadId: 'mp1' }]);
   });
 
   it('listItems sends vaultId and returns items', async () => {

--- a/packages/web/src/api/items.ts
+++ b/packages/web/src/api/items.ts
@@ -1,6 +1,8 @@
 import {
   InitiateItemUploadCommand,
   CompleteItemUploadCommand,
+  CreateUploadPartUrlsCommand,
+  AbortItemUploadCommand,
   ListItemsCommand,
   GetItemDownloadUrlCommand,
   DeleteItemCommand,
@@ -8,17 +10,20 @@ import {
 import type { ItemData } from '@cortex/client';
 import { makeClient } from './client';
 
+export type UploadedPart = { partNumber: number; eTag: string };
+
 export async function initiateUpload(args: {
   vaultId: string;
   encryptedMetadata: Uint8Array;
   sizeBytes: number;
-}): Promise<{ itemId: string; uploadUrl: string }> {
+}): Promise<{ itemId: string; uploadUrl: string; uploadId?: string }> {
   const out = await makeClient().send(new InitiateItemUploadCommand(args));
   if (!out.itemId || !out.uploadUrl) throw new Error('initiateUpload: incomplete response');
-  return { itemId: out.itemId, uploadUrl: out.uploadUrl };
+  // uploadId is present only when the server chose multipart (sizeBytes > threshold).
+  return { itemId: out.itemId, uploadUrl: out.uploadUrl, uploadId: out.uploadId };
 }
 
-export async function putToS3(uploadUrl: string, blob: Uint8Array): Promise<void> {
+export async function putToS3(uploadUrl: string, blob: Uint8Array): Promise<string> {
   // Raw PUT to the presigned URL — not a Smithy op, so no Authorization header
   // (the URL carries auth). The body is opaque ciphertext → octet-stream; the
   // real MIME lives only in the encrypted metadata.
@@ -30,10 +35,36 @@ export async function putToS3(uploadUrl: string, blob: Uint8Array): Promise<void
     headers: { 'Content-Type': 'application/octet-stream' },
   });
   if (!res.ok) throw new Error(`S3 upload failed: ${res.status}`);
+  // Multipart completion needs each part's ETag. The browser can only read it if
+  // the bucket CORS lists ETag under ExposeHeaders — otherwise this is null.
+  const eTag = res.headers.get('ETag') ?? res.headers.get('etag');
+  if (!eTag) throw new Error('S3 upload: missing ETag (bucket CORS must expose ETag)');
+  return eTag;
 }
 
-export async function completeUpload(itemId: string): Promise<void> {
-  await makeClient().send(new CompleteItemUploadCommand({ itemId }));
+export async function createUploadPartUrls(
+  itemId: string,
+  uploadId: string,
+  partNumbers: number[],
+): Promise<{ partNumber: number; url: string }[]> {
+  const out = await makeClient().send(
+    new CreateUploadPartUrlsCommand({ itemId, uploadId, partNumbers }),
+  );
+  return (out.urls ?? []).map((u) => {
+    if (u.partNumber == null || !u.url) throw new Error('createUploadPartUrls: incomplete URL');
+    return { partNumber: u.partNumber, url: u.url };
+  });
+}
+
+export async function completeUpload(
+  itemId: string,
+  opts?: { uploadId: string; parts: UploadedPart[] },
+): Promise<void> {
+  await makeClient().send(new CompleteItemUploadCommand({ itemId, ...opts }));
+}
+
+export async function abortUpload(itemId: string, uploadId: string): Promise<void> {
+  await makeClient().send(new AbortItemUploadCommand({ itemId, uploadId }));
 }
 
 export async function listItems(vaultId: string): Promise<ItemData[]> {

--- a/packages/web/src/components/FileUpload.test.tsx
+++ b/packages/web/src/components/FileUpload.test.tsx
@@ -2,46 +2,48 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-const enc = new Uint8Array([7, 7]);
 const h = vi.hoisted(() => ({
   getVaultKeys: vi.fn(async () => ({ vaultId: 'v1', kek: new Uint8Array(32), metadataKey: new Uint8Array(32) })),
-  encryptFileForUpload: vi.fn(async () => ({ blob: new Uint8Array([9, 9]), encryptedMetadata: new Uint8Array([7, 7]), metadata: {} })),
-  initiateUpload: vi.fn(async () => ({ itemId: 'i1', uploadUrl: 'https://s3/put' })),
-  putToS3: vi.fn(async () => {}),
-  completeUpload: vi.fn(async () => {}),
+  uploadFileStreaming: vi.fn(async () => {}),
 }));
 vi.mock('../vault/keyAccess', () => ({ getVaultKeys: h.getVaultKeys }));
-vi.mock('../items/itemCrypto', () => ({ encryptFileForUpload: h.encryptFileForUpload }));
-vi.mock('../api/items', () => ({ initiateUpload: h.initiateUpload, putToS3: h.putToS3, completeUpload: h.completeUpload }));
+vi.mock('../items/streamingUpload', () => ({ uploadFileStreaming: h.uploadFileStreaming }));
 
 import FileUpload, { MAX_FILE_SIZE_BYTES } from './FileUpload';
 
 beforeEach(() => vi.clearAllMocks());
 
 function pick(name: string, bytes: number, type = 'image/png') {
-  const file = new File([new Uint8Array(bytes)], name, { type });
-  // jsdom File.size reflects the byte length; override for the over-cap case cheaply:
+  const file = new File([new Uint8Array(Math.min(bytes, 4))], name, { type });
+  // jsdom File.size reflects byte length; override cheaply for the over-cap case.
   Object.defineProperty(file, 'size', { value: bytes });
-  file.arrayBuffer = async () => new Uint8Array(Math.min(bytes, 4)).buffer;
   return file;
 }
 
 describe('FileUpload', () => {
-  it('runs init → PUT → complete in order and calls onUploaded', async () => {
+  it('delegates to uploadFileStreaming and calls onUploaded', async () => {
     const onUploaded = vi.fn();
     render(<FileUpload onUploaded={onUploaded} />);
     await userEvent.upload(screen.getByLabelText(/upload/i), pick('a.png', 3));
     await waitFor(() => expect(onUploaded).toHaveBeenCalled());
-    expect(h.encryptFileForUpload).toHaveBeenCalled();
-    expect(h.initiateUpload).toHaveBeenCalledWith({ vaultId: 'v1', encryptedMetadata: enc, sizeBytes: 2 });
-    expect(h.putToS3).toHaveBeenCalledWith('https://s3/put', new Uint8Array([9, 9]));
-    expect(h.completeUpload).toHaveBeenCalledWith('i1');
+    expect(h.uploadFileStreaming).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'a.png' }),
+      expect.objectContaining({ vaultId: 'v1' }),
+      expect.any(Function),
+    );
   });
 
-  it('rejects files over the cap without uploading', async () => {
+  it('rejects files over the 5 GB cap without uploading', async () => {
     render(<FileUpload onUploaded={vi.fn()} />);
     await userEvent.upload(screen.getByLabelText(/upload/i), pick('big.bin', MAX_FILE_SIZE_BYTES + 1));
-    expect(await screen.findByRole('alert')).toHaveTextContent(/100 ?MB/i);
-    expect(h.initiateUpload).not.toHaveBeenCalled();
+    expect(await screen.findByRole('alert')).toHaveTextContent(/5 ?GB/i);
+    expect(h.uploadFileStreaming).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an upload error', async () => {
+    h.uploadFileStreaming.mockRejectedValueOnce(new Error('integrity check failed'));
+    render(<FileUpload onUploaded={vi.fn()} />);
+    await userEvent.upload(screen.getByLabelText(/upload/i), pick('a.png', 3));
+    expect(await screen.findByRole('alert')).toHaveTextContent(/integrity check failed/i);
   });
 });

--- a/packages/web/src/components/FileUpload.tsx
+++ b/packages/web/src/components/FileUpload.tsx
@@ -1,12 +1,14 @@
 import { useState } from 'react';
 import { getVaultKeys } from '../vault/keyAccess';
-import { encryptFileForUpload } from '../items/itemCrypto';
-import { initiateUpload, putToS3, completeUpload } from '../api/items';
+import { uploadFileStreaming } from '../items/streamingUpload';
 
-export const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
+// Soft ceiling ~5 GB. S3 multipart's hard cap at 8 MiB parts is ~80 GB; we guard
+// well below that and show a clear message instead of letting a huge file hang.
+export const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024 * 1024;
 
 export default function FileUpload({ onUploaded }: { onUploaded: () => void }) {
   const [busy, setBusy] = useState(false);
+  const [progress, setProgress] = useState(0);
   const [error, setError] = useState('');
 
   async function onChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -15,23 +17,14 @@ export default function FileUpload({ onUploaded }: { onUploaded: () => void }) {
     if (!file) return;
     setError('');
     if (file.size > MAX_FILE_SIZE_BYTES) {
-      setError("Files over 100 MB aren't supported yet — large-file streaming is coming.");
+      setError('Files over 5 GB aren’t supported.');
       return;
     }
     setBusy(true);
+    setProgress(0);
     try {
-      const bytes = new Uint8Array(await file.arrayBuffer());
       const keys = await getVaultKeys();
-      const { blob, encryptedMetadata } = await encryptFileForUpload(
-        bytes, file.name, file.type || 'application/octet-stream', keys,
-      );
-      const { itemId, uploadUrl } = await initiateUpload({
-        vaultId: keys.vaultId,
-        encryptedMetadata,
-        sizeBytes: blob.length,
-      });
-      await putToS3(uploadUrl, blob);
-      await completeUpload(itemId);
+      await uploadFileStreaming(file, keys, setProgress);
       onUploaded();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Upload failed');
@@ -46,7 +39,7 @@ export default function FileUpload({ onUploaded }: { onUploaded: () => void }) {
         Upload file
         <input type="file" onChange={onChange} disabled={busy} />
       </label>
-      {busy && <p>Encrypting and uploading…</p>}
+      {busy && <p>Encrypting and uploading… {Math.round(progress * 100)}%</p>}
       {error && <p role="alert">{error}</p>}
     </div>
   );

--- a/packages/web/src/items/itemCrypto.test.ts
+++ b/packages/web/src/items/itemCrypto.test.ts
@@ -1,35 +1,39 @@
 import { describe, it, expect } from 'vitest';
-import { deriveKeys } from '@cortex/encryption';
-import { encryptFileForUpload, decryptDownloadedBlob } from './itemCrypto';
-import { decryptMetadata } from './metadata';
+import { deriveKeys, encryptFileWithDek } from '@cortex/encryption';
+import { decryptDownloadedBlob } from './itemCrypto';
+import { encodeItemBlob } from './itemBlob';
+import type { FileMetadata } from './metadata';
 
 const keys = (() => {
   const k = deriveKeys(new Uint8Array(32).fill(5));
   return { kek: k.keyEncryptionKey, metadataKey: k.metadataEncryptionKey };
 })();
 
-describe('item crypto', () => {
-  it('encrypts then decrypts a file end-to-end', async () => {
-    const bytes = new TextEncoder().encode('the secret photo bytes');
-    const { blob, encryptedMetadata, metadata } = await encryptFileForUpload(
-      bytes, 'photo.jpg', 'image/jpeg', keys,
-    );
-    expect(metadata).toMatchObject({ name: 'photo.jpg', contentType: 'image/jpeg', size: bytes.length });
-    expect(metadata.contentId).toMatch(/[0-9a-f-]{36}/);
+// Build a legacy (Slice 2) blob from the envelope primitives — the format
+// decryptDownloadedBlob consumes for pre-2.5c objects.
+async function legacyBlob(bytes: Uint8Array, contentId: string): Promise<Uint8Array> {
+  const { encryptedContent, wrappedDek } = await encryptFileWithDek(bytes, keys.kek, contentId);
+  return encodeItemBlob(wrappedDek, encryptedContent);
+}
 
-    const meta = decryptMetadata(encryptedMetadata, keys.metadataKey);
+describe('item crypto (legacy download path)', () => {
+  it('decrypts a legacy blob end-to-end', async () => {
+    const bytes = new TextEncoder().encode('the secret photo bytes');
+    const meta: FileMetadata = { name: 'photo.jpg', contentType: 'image/jpeg', size: bytes.length, contentId: crypto.randomUUID() };
+    const blob = await legacyBlob(bytes, meta.contentId);
+
     const out = decryptDownloadedBlob(blob, meta, keys.kek);
     // Array.from both sides: under jsdom, the crypto lib's Uint8Array (Node realm)
     // and the test's TextEncoder Uint8Array (jsdom realm) are byte-identical but
-    // cross-realm, so toEqual on the raw arrays fails. Comparing plain arrays is
-    // realm-agnostic and still checks every byte.
+    // cross-realm, so toEqual on the raw arrays fails. Plain arrays are realm-agnostic.
     expect(Array.from(out)).toEqual(Array.from(bytes));
   });
 
   it('fails the HMAC binding if contentId is tampered', async () => {
     const bytes = new TextEncoder().encode('x');
-    const { blob, metadata } = await encryptFileForUpload(bytes, 'a', 'text/plain', keys);
-    const tampered = { ...metadata, contentId: 'different-content-id' };
+    const contentId = crypto.randomUUID();
+    const blob = await legacyBlob(bytes, contentId);
+    const tampered: FileMetadata = { name: 'a', contentType: 'text/plain', size: 1, contentId: 'different-content-id' };
     expect(() => decryptDownloadedBlob(blob, tampered, keys.kek)).toThrow();
   });
 });

--- a/packages/web/src/items/itemCrypto.ts
+++ b/packages/web/src/items/itemCrypto.ts
@@ -1,22 +1,10 @@
-import { encryptFileWithDek, decryptFileWithDek } from '@cortex/encryption';
-import { encodeItemBlob, decodeItemBlob } from './itemBlob';
-import { encryptMetadata, type FileMetadata } from './metadata';
+import { decryptFileWithDek } from '@cortex/encryption';
+import { decodeItemBlob } from './itemBlob';
+import { type FileMetadata } from './metadata';
 
-export async function encryptFileForUpload(
-  bytes: Uint8Array,
-  name: string,
-  contentType: string,
-  keys: { kek: Uint8Array; metadataKey: Uint8Array },
-): Promise<{ blob: Uint8Array; encryptedMetadata: Uint8Array; metadata: FileMetadata }> {
-  const contentId = crypto.randomUUID();
-  // fileId = contentId binds the DEK to this file (HMAC); wrappedDek is 97 bytes.
-  const { encryptedContent, wrappedDek } = await encryptFileWithDek(bytes, keys.kek, contentId);
-  const blob = encodeItemBlob(wrappedDek, encryptedContent);
-  const metadata: FileMetadata = { name, contentType, size: bytes.length, contentId };
-  const encryptedMetadata = await encryptMetadata(metadata, keys.metadataKey);
-  return { blob, encryptedMetadata, metadata };
-}
-
+// Legacy (Slice 2) whole-buffer download path. New uploads use the chunked
+// streaming format (see streamingUpload.ts); the download path selects this only
+// when metadata has no streamVersion. Kept for objects uploaded before 2.5c.
 export function decryptDownloadedBlob(
   blob: Uint8Array,
   metadata: FileMetadata,

--- a/packages/web/src/items/metadata.ts
+++ b/packages/web/src/items/metadata.ts
@@ -5,6 +5,9 @@ export interface FileMetadata {
   contentType: string;
   size: number;
   contentId: string;
+  // Set to STREAM_VERSION for chunked-stream uploads (2.5c). Absent ⇒ legacy
+  // Slice 2 whole-buffer object; the download path dispatches on this.
+  streamVersion?: number;
 }
 
 // Adapted for #208: the Smithy `encryptedMetadata` field is a Blob (Uint8Array)

--- a/packages/web/src/items/streamingUpload.test.ts
+++ b/packages/web/src/items/streamingUpload.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { decryptMetadata } from './metadata';
+
+const api = vi.hoisted(() => ({
+  initiateUpload: vi.fn(),
+  putToS3: vi.fn(),
+  createUploadPartUrls: vi.fn(),
+  completeUpload: vi.fn(),
+  abortUpload: vi.fn(),
+}));
+vi.mock('../api/items', () => api);
+
+import { uploadFileStreaming } from './streamingUpload';
+
+const keys = { vaultId: 'v1', kek: new Uint8Array(32), metadataKey: new Uint8Array(32) };
+
+// File-like stub: deterministic slice/arrayBuffer, no jsdom Blob dependency.
+function fakeFile(bytes: Uint8Array, name = 'f.bin', type = 'image/png'): File {
+  return {
+    name,
+    type,
+    size: bytes.length,
+    slice: (s: number, e: number) => ({ arrayBuffer: async () => bytes.slice(s, e).buffer }),
+  } as unknown as File;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.putToS3.mockResolvedValue('"etag"');
+  api.completeUpload.mockResolvedValue(undefined);
+  api.abortUpload.mockResolvedValue(undefined);
+  api.createUploadPartUrls.mockImplementation(async (_i: string, _u: string, parts: number[]) =>
+    parts.map((n) => ({ partNumber: n, url: `https://s3/p${n}` })),
+  );
+});
+
+describe('uploadFileStreaming', () => {
+  it('single-PUT path: assembles one blob, completes with no parts, sets streamVersion', async () => {
+    api.initiateUpload.mockResolvedValue({ itemId: 'i1', uploadUrl: 'https://s3/put' }); // no uploadId
+    const onProgress = vi.fn();
+    await uploadFileStreaming(fakeFile(new Uint8Array([1, 2, 3])), keys, onProgress);
+
+    // sizeBytes = 97 + 13 + 3 + 16 = 129 (1 chunk)
+    expect(api.initiateUpload).toHaveBeenCalledWith(
+      expect.objectContaining({ vaultId: 'v1', sizeBytes: 129 }),
+    );
+    const meta = decryptMetadata(api.initiateUpload.mock.calls[0][0].encryptedMetadata, keys.metadataKey);
+    expect(meta).toMatchObject({ name: 'f.bin', size: 3, streamVersion: 1 });
+    expect(api.putToS3).toHaveBeenCalledTimes(1);
+    expect(api.putToS3.mock.calls[0][0]).toBe('https://s3/put');
+    expect(api.putToS3.mock.calls[0][1].length).toBe(129);
+    expect(api.completeUpload).toHaveBeenCalledWith('i1'); // no opts
+    expect(onProgress).toHaveBeenLastCalledWith(1);
+  });
+
+  it('multipart path: parts uploaded in order, eTags collected, complete gets ordered parts', async () => {
+    api.initiateUpload.mockResolvedValue({ itemId: 'i1', uploadUrl: 'https://s3/put', uploadId: 'mp1' });
+    api.putToS3.mockImplementation(async (url: string) => `"e-${url.slice(-2)}"`);
+    // 10 bytes, chunkSize 4 → 3 parts (4, 4, 2)
+    await uploadFileStreaming(fakeFile(new Uint8Array(10)), keys, undefined, { chunkSize: 4 });
+
+    expect(api.createUploadPartUrls).toHaveBeenCalledWith('i1', 'mp1', [1, 2, 3]);
+    const putUrls = api.putToS3.mock.calls.map((c: unknown[]) => c[0]);
+    expect(putUrls).toEqual(['https://s3/p1', 'https://s3/p2', 'https://s3/p3']);
+    // part 1 body = 97 + 13 + (4 + 16) = 130; part 2 = 20; part 3 = (2 + 16) = 18
+    expect(api.putToS3.mock.calls.map((c: { length: number }[]) => c[1].length)).toEqual([130, 20, 18]);
+    expect(api.completeUpload).toHaveBeenCalledWith('i1', {
+      uploadId: 'mp1',
+      parts: [
+        { partNumber: 1, eTag: '"e-p1"' },
+        { partNumber: 2, eTag: '"e-p2"' },
+        { partNumber: 3, eTag: '"e-p3"' },
+      ],
+    });
+    expect(api.abortUpload).not.toHaveBeenCalled();
+  });
+
+  it('retries a failing part, then completes without aborting', async () => {
+    api.initiateUpload.mockResolvedValue({ itemId: 'i1', uploadUrl: 'x', uploadId: 'mp1' });
+    let calls = 0;
+    api.putToS3.mockImplementation(async () => {
+      calls += 1;
+      if (calls === 1) throw new Error('flaky');
+      return '"e"';
+    });
+    await uploadFileStreaming(fakeFile(new Uint8Array(3)), keys, undefined, { chunkSize: 4 });
+    expect(calls).toBe(2); // 1 fail + 1 success on the single part
+    expect(api.completeUpload).toHaveBeenCalled();
+    expect(api.abortUpload).not.toHaveBeenCalled();
+  });
+
+  it('aborts the multipart upload and rethrows when a part exhausts its retries', async () => {
+    api.initiateUpload.mockResolvedValue({ itemId: 'i1', uploadUrl: 'x', uploadId: 'mp1' });
+    api.putToS3.mockRejectedValue(new Error('dead'));
+    await expect(
+      uploadFileStreaming(fakeFile(new Uint8Array(3)), keys, undefined, { chunkSize: 4 }),
+    ).rejects.toThrow('dead');
+    expect(api.abortUpload).toHaveBeenCalledWith('i1', 'mp1');
+    expect(api.completeUpload).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/items/streamingUpload.ts
+++ b/packages/web/src/items/streamingUpload.ts
@@ -1,0 +1,155 @@
+import {
+  generateDek,
+  wrapDek,
+  generateNoncePrefix,
+  buildStreamHeader,
+  encryptChunk,
+  DEFAULT_CHUNK_SIZE,
+  STREAM_HEADER_SIZE,
+  STREAM_VERSION,
+} from '@cortex/encryption';
+import { WRAPPED_DEK_SIZE } from './itemBlob';
+import { encryptMetadata, type FileMetadata } from './metadata';
+import {
+  initiateUpload,
+  putToS3,
+  createUploadPartUrls,
+  completeUpload,
+  abortUpload,
+  type UploadedPart,
+} from '../api/items';
+
+const TAG_SIZE = 16;
+const PART_URL_BATCH = 10;
+const PART_RETRIES = 3;
+
+export interface VaultKeys {
+  vaultId: string;
+  kek: Uint8Array;
+  metadataKey: Uint8Array;
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+  let o = 0;
+  for (const p of parts) {
+    out.set(p, o);
+    o += p.length;
+  }
+  return out;
+}
+
+async function withRetry<T>(fn: () => Promise<T>, retries = PART_RETRIES): Promise<T> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (attempt < retries) await new Promise((r) => setTimeout(r, 200 * 2 ** attempt));
+    }
+  }
+  throw lastErr;
+}
+
+/**
+ * Encrypt a file as a chunked stream and upload it.
+ *
+ * The on-disk format is always the 2.5a chunked layout
+ * `[wrappedDek(97)][header(13)][chunk0…chunkN]`. Transport branches on whether
+ * the server returned a multipart `uploadId`: absent → one presigned PUT;
+ * present → one S3 part per chunk (1-based) with batched part URLs and per-part
+ * retry, aborting on fatal failure. Multipart memory stays O(chunkSize).
+ */
+export async function uploadFileStreaming(
+  file: File,
+  keys: VaultKeys,
+  onProgress?: (fraction: number) => void,
+  opts?: { chunkSize?: number }, // ponytail: chunkSize is in the header anyway; override is test-only
+): Promise<void> {
+  const chunkSize = opts?.chunkSize ?? DEFAULT_CHUNK_SIZE;
+  const plaintextSize = file.size;
+  const partCount = Math.max(1, Math.ceil(plaintextSize / chunkSize));
+  const sizeBytes = WRAPPED_DEK_SIZE + STREAM_HEADER_SIZE + plaintextSize + TAG_SIZE * partCount;
+
+  const contentId = crypto.randomUUID();
+  const dek = await generateDek();
+  try {
+    const wrappedDek = await wrapDek(dek, keys.kek, contentId);
+    const noncePrefix = await generateNoncePrefix();
+    const header = buildStreamHeader(chunkSize, noncePrefix);
+
+    const metadata: FileMetadata = {
+      name: file.name,
+      contentType: file.type || 'application/octet-stream',
+      size: plaintextSize,
+      contentId,
+      streamVersion: STREAM_VERSION,
+    };
+    const encryptedMetadata = await encryptMetadata(metadata, keys.metadataKey);
+
+    const { itemId, uploadUrl, uploadId } = await initiateUpload({
+      vaultId: keys.vaultId,
+      encryptedMetadata,
+      sizeBytes,
+    });
+
+    // Read + encrypt one chunk lazily; part 1 prepends wrappedDek + header.
+    const encryptPart = async (index: number): Promise<Uint8Array> => {
+      const start = index * chunkSize;
+      const end = Math.min(start + chunkSize, plaintextSize);
+      const plain = new Uint8Array(await file.slice(start, end).arrayBuffer());
+      const ct = encryptChunk(plain, {
+        dek,
+        noncePrefix,
+        index,
+        isFinal: index === partCount - 1,
+        contentId,
+        header,
+      });
+      return index === 0 ? concat([wrappedDek, header, ct]) : ct;
+    };
+
+    let uploaded = 0;
+    const bump = (n: number) => {
+      uploaded += n;
+      onProgress?.(uploaded / sizeBytes);
+    };
+
+    if (!uploadId) {
+      // Single-PUT: assemble the whole object (≤ threshold) and PUT once.
+      const blobs: Uint8Array[] = [];
+      for (let i = 0; i < partCount; i++) blobs.push(await encryptPart(i));
+      const blob = concat(blobs);
+      await putToS3(uploadUrl, blob);
+      bump(blob.length);
+      await completeUpload(itemId);
+      return;
+    }
+
+    // Multipart: one S3 part per chunk (1-based), batched part URLs, per-part retry.
+    try {
+      const parts: UploadedPart[] = [];
+      for (let base = 1; base <= partCount; base += PART_URL_BATCH) {
+        const nums: number[] = [];
+        for (let n = base; n < base + PART_URL_BATCH && n <= partCount; n++) nums.push(n);
+        const urls = await createUploadPartUrls(itemId, uploadId, nums);
+        const urlByPart = new Map(urls.map((u) => [u.partNumber, u.url]));
+        for (const partNumber of nums) {
+          const body = await encryptPart(partNumber - 1);
+          const url = urlByPart.get(partNumber);
+          if (!url) throw new Error(`Missing part URL for part ${partNumber}`);
+          const eTag = await withRetry(() => putToS3(url, body));
+          parts.push({ partNumber, eTag });
+          bump(body.length);
+        }
+      }
+      await completeUpload(itemId, { uploadId, parts });
+    } catch (err) {
+      await abortUpload(itemId, uploadId).catch(() => {}); // best-effort cleanup
+      throw err;
+    }
+  } finally {
+    dek.fill(0);
+  }
+}


### PR DESCRIPTION
## Phase B · Slice 2.5c — Streaming Upload (frontend)

Replaces `FileUpload`'s whole-buffer 100 MB path with a chunked, streaming upload. Consumes the 2.5a chunked-AEAD primitive and the 2.5b multipart contract (#212). Sibling of 2.5d (streaming download, separate).

### What changed
- **`api/items.ts`** — multipart helpers: `initiateUpload` now surfaces `uploadId`; `putToS3` returns the part ETag; new `createUploadPartUrls` / `abortUpload`; `completeUpload` accepts `{uploadId, parts}`.
- **`items/streamingUpload.ts`** (new) — `uploadFileStreaming(file, keys, onProgress)`. Always writes the chunked layout `[wrappedDek(97)][header(13)][chunk0…chunkN]`; transport branches on whether the server returned a multipart `uploadId`:
  - **single-PUT** (≤ threshold): assemble + one PUT.
  - **multipart** (> threshold): one S3 part per 8 MiB chunk (1-based, part 1 carries the preamble), batched part URLs (×10), per-part retry (×3, backoff), `AbortItemUpload` on fatal failure. Memory O(chunkSize).
- **`items/metadata.ts`** — `FileMetadata.streamVersion` (set to `1`) so 2.5d dispatches chunked vs legacy.
- **`components/FileUpload.tsx`** — delegates to `uploadFileStreaming`, raises the cap to 5 GB, shows progress.
- **`items/itemCrypto.ts`** — drops the now-dead `encryptFileForUpload` (it produced the *legacy* format and had no live caller); keeps `decryptDownloadedBlob` for legacy/2.5d downloads.

### Zero-knowledge / integrity
- `sizeBytes` is byte-exact (`97+13+plaintext+16·partCount`) so the server's threshold decision matches the assembled object.
- DEK zeroed in `finally` after the whole multipart loop (no use-after-wipe).
- Every non-last S3 part is a full 8 MiB chunk ≥ S3's 5 MiB floor; only the exempt last part can be smaller.

### Browser multipart prereq — already satisfied
`putToS3` reads the part `ETag` response header, which needs the files bucket CORS to expose it. Already configured: `cdk/lib/stacks/service.ts:104` `exposedHeaders: ["ETag"]`. Just confirm the stack is deployed during the (still-unrun) live Cognito/S3 smoke.

### Tests
`npm --prefix packages/web test` → **60/60 green**; `tsc` + `vite build` clean. Covers: parts in order, eTags collected, complete with ordered parts, retry, abort-on-give-up, progress, single-PUT, `streamVersion`.