### PR TITLE
feat(web): Phase B Slice 2.5d — streaming chunked download (File System Access + blob fallback)

### DIFF
--- a/packages/web/src/components/FileList.test.tsx
+++ b/packages/web/src/components/FileList.test.tsx
@@ -1,13 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { FileMetadata } from '../items/metadata';
 
 const h = vi.hoisted(() => ({
   getVaultKeys: vi.fn(async () => ({ vaultId: 'v1', kek: new Uint8Array(32), metadataKey: new Uint8Array(32) })),
   listItems: vi.fn(async () => [{ itemId: 'i1', encryptedMetadata: new Uint8Array([1]), createdAt: new Date(1000) }]),
   getDownloadUrl: vi.fn(async () => 'https://s3/get'),
   deleteItem: vi.fn(async () => {}),
-  decryptMetadata: vi.fn(() => ({ name: 'cat.png', contentType: 'image/png', size: 1234, contentId: 'c1' })),
+  decryptMetadata: vi.fn((): FileMetadata => ({ name: 'cat.png', contentType: 'image/png', size: 1234, contentId: 'c1' })),
   decryptDownloadedBlob: vi.fn(() => new Uint8Array([1, 2, 3])),
   pickSink: vi.fn(async () => ({ write: vi.fn(), close: vi.fn(), abort: vi.fn() })),
   downloadFileStreaming: vi.fn(async () => {}),

--- a/packages/web/src/components/FileList.test.tsx
+++ b/packages/web/src/components/FileList.test.tsx
@@ -9,11 +9,14 @@ const h = vi.hoisted(() => ({
   deleteItem: vi.fn(async () => {}),
   decryptMetadata: vi.fn(() => ({ name: 'cat.png', contentType: 'image/png', size: 1234, contentId: 'c1' })),
   decryptDownloadedBlob: vi.fn(() => new Uint8Array([1, 2, 3])),
+  pickSink: vi.fn(async () => ({ write: vi.fn(), close: vi.fn(), abort: vi.fn() })),
+  downloadFileStreaming: vi.fn(async () => {}),
 }));
 vi.mock('../vault/keyAccess', () => ({ getVaultKeys: h.getVaultKeys }));
 vi.mock('../api/items', () => ({ listItems: h.listItems, getDownloadUrl: h.getDownloadUrl, deleteItem: h.deleteItem }));
 vi.mock('../items/metadata', () => ({ decryptMetadata: h.decryptMetadata }));
 vi.mock('../items/itemCrypto', () => ({ decryptDownloadedBlob: h.decryptDownloadedBlob }));
+vi.mock('../items/streamingDownload', () => ({ pickSink: h.pickSink, downloadFileStreaming: h.downloadFileStreaming }));
 
 import FileList from './FileList';
 
@@ -30,12 +33,32 @@ describe('FileList', () => {
     expect(await screen.findByText('cat.png')).toBeInTheDocument();
   });
 
-  it('download fetches the url, decrypts, and triggers a save', async () => {
+  it('legacy download (no streamVersion) fetches the url, decrypts whole-buffer, saves', async () => {
     render(<FileList refreshKey={0} />);
     await screen.findByText('cat.png');
     await userEvent.click(screen.getByRole('button', { name: /download/i }));
     await waitFor(() => expect(h.getDownloadUrl).toHaveBeenCalledWith('i1'));
     expect(h.decryptDownloadedBlob).toHaveBeenCalled();
+    expect(h.downloadFileStreaming).not.toHaveBeenCalled();
+  });
+
+  it('chunked download (streamVersion present) picks a sink and streams', async () => {
+    // Once only — clearAllMocks doesn't restore an overridden implementation, so a
+    // persistent mockReturnValue would leak streamVersion into later tests.
+    h.decryptMetadata.mockReturnValueOnce({
+      name: 'big.bin', contentType: 'application/octet-stream', size: 999, contentId: 'c2', streamVersion: 1,
+    });
+    render(<FileList refreshKey={0} />);
+    await screen.findByText('big.bin');
+    await userEvent.click(screen.getByRole('button', { name: /download/i }));
+    await waitFor(() => expect(h.pickSink).toHaveBeenCalledWith('big.bin', 'application/octet-stream'));
+    expect(h.downloadFileStreaming).toHaveBeenCalledWith(
+      'i1',
+      expect.objectContaining({ streamVersion: 1 }),
+      expect.any(Uint8Array),
+      expect.anything(),
+    );
+    expect(h.decryptDownloadedBlob).not.toHaveBeenCalled();
   });
 
   it('delete calls the API then reloads the list', async () => {

--- a/packages/web/src/components/FileList.tsx
+++ b/packages/web/src/components/FileList.tsx
@@ -3,6 +3,7 @@ import { getVaultKeys } from '../vault/keyAccess';
 import { listItems, getDownloadUrl, deleteItem } from '../api/items';
 import { decryptMetadata, type FileMetadata } from '../items/metadata';
 import { decryptDownloadedBlob } from '../items/itemCrypto';
+import { pickSink, downloadFileStreaming } from '../items/streamingDownload';
 
 interface Row {
   itemId: string;
@@ -41,16 +42,32 @@ export default function FileList({ refreshKey }: { refreshKey: number }) {
 
   async function onDownload(row: Row) {
     if (!row.meta) return;
-    const { kek } = await getVaultKeys();
-    const url = await getDownloadUrl(row.itemId);
-    const blob = new Uint8Array(await (await fetch(url)).arrayBuffer());
-    const plain = decryptDownloadedBlob(blob, row.meta, kek);
-    const objectUrl = URL.createObjectURL(new Blob([plain as BlobPart], { type: row.meta.contentType }));
-    const a = document.createElement('a');
-    a.href = objectUrl;
-    a.download = row.meta.name;
-    a.click();
-    URL.revokeObjectURL(objectUrl);
+    setError('');
+    try {
+      // streamVersion is already known from the decrypted metadata — branch with
+      // no await so the user gesture survives for showSaveFilePicker.
+      if (row.meta.streamVersion === undefined) {
+        // Legacy (pre-2.5c) whole-buffer object.
+        const { kek } = await getVaultKeys();
+        const url = await getDownloadUrl(row.itemId);
+        const blob = new Uint8Array(await (await fetch(url)).arrayBuffer());
+        const plain = decryptDownloadedBlob(blob, row.meta, kek);
+        const objectUrl = URL.createObjectURL(new Blob([plain as BlobPart], { type: row.meta.contentType }));
+        const a = document.createElement('a');
+        a.href = objectUrl;
+        a.download = row.meta.name;
+        a.click();
+        URL.revokeObjectURL(objectUrl);
+        return;
+      }
+      // Chunked stream: pick the sink FIRST (preserves the click's user activation).
+      const sink = await pickSink(row.meta.name, row.meta.contentType);
+      const { kek } = await getVaultKeys();
+      await downloadFileStreaming(row.itemId, row.meta, kek, sink);
+    } catch (err) {
+      if ((err as Error)?.name === 'AbortError') return; // user cancelled the save dialog
+      setError(err instanceof Error ? err.message : 'Download failed');
+    }
   }
 
   async function onDelete(itemId: string) {

--- a/packages/web/src/items/streamingDownload.test.ts
+++ b/packages/web/src/items/streamingDownload.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  generateDek, wrapDek, generateNoncePrefix, buildStreamHeader, encryptChunk,
+} from '@cortex/encryption';
+import type { FileMetadata } from './metadata';
+
+const api = vi.hoisted(() => ({ getDownloadUrl: vi.fn(async () => 'https://s3/get') }));
+vi.mock('../api/items', () => api);
+
+import { downloadFileStreaming, type DownloadSink } from './streamingDownload';
+
+const kek = new Uint8Array(32).fill(7);
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+  let o = 0;
+  for (const p of parts) { out.set(p, o); o += p.length; }
+  return out;
+}
+
+// Build the on-disk chunked object [wrappedDek(97)][header(13)][chunk0…chunkN].
+async function buildObject(plaintext: Uint8Array, contentId: string, chunkSize: number): Promise<Uint8Array> {
+  const dek = await generateDek();
+  const wrappedDek = await wrapDek(dek, kek, contentId);
+  const noncePrefix = await generateNoncePrefix();
+  const header = buildStreamHeader(chunkSize, noncePrefix);
+  const partCount = Math.max(1, Math.ceil(plaintext.length / chunkSize));
+  const chunks: Uint8Array[] = [];
+  for (let i = 0; i < partCount; i++) {
+    chunks.push(encryptChunk(plaintext.slice(i * chunkSize, (i + 1) * chunkSize), {
+      dek, noncePrefix, index: i, isFinal: i === partCount - 1, contentId, header,
+    }));
+  }
+  return concat([wrappedDek, header, ...chunks]);
+}
+
+// ReadableStream that hands out `readSize` bytes per pull — small value stresses framing.
+function streamOf(bytes: Uint8Array, readSize = 7): ReadableStream<Uint8Array> {
+  let pos = 0;
+  return new ReadableStream({
+    pull(c) {
+      if (pos >= bytes.length) { c.close(); return; }
+      c.enqueue(bytes.slice(pos, pos + readSize));
+      pos += readSize;
+    },
+  });
+}
+
+function fakeSink() {
+  const writes: Uint8Array[] = [];
+  const state = { closed: false, aborted: false };
+  const sink: DownloadSink = {
+    write: (b) => { writes.push(b); },
+    close: () => { state.closed = true; },
+    abort: () => { state.aborted = true; },
+  };
+  return { sink, writes, state };
+}
+
+const meta = (contentId: string): FileMetadata =>
+  ({ name: 'f.bin', contentType: 'application/octet-stream', size: 0, contentId, streamVersion: 1 });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('downloadFileStreaming', () => {
+  it.each([
+    ['empty', 0],
+    ['sub-chunk', 3],
+    ['exact multiple', 8],
+    ['multi-chunk + remainder', 21],
+  ])('round-trips %s (chunkSize 4)', async (_label, size) => {
+    const plaintext = new Uint8Array(Array.from({ length: size }, (_, i) => (i * 7) & 0xff));
+    const contentId = crypto.randomUUID();
+    const object = await buildObject(plaintext, contentId, 4);
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, body: streamOf(object) })));
+
+    const { sink, writes, state } = fakeSink();
+    await downloadFileStreaming('i1', meta(contentId), kek, sink);
+
+    expect(Array.from(concat(writes))).toEqual(Array.from(plaintext));
+    expect(state.closed).toBe(true);
+    expect(state.aborted).toBe(false);
+  });
+
+  it('aborts the sink and throws an integrity error on a tampered chunk', async () => {
+    const plaintext = new Uint8Array(20);
+    const contentId = crypto.randomUUID();
+    const object = await buildObject(plaintext, contentId, 4);
+    object[object.length - 1] ^= 0xff; // flip a byte in the final tag
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, body: streamOf(object) })));
+
+    const { sink, state } = fakeSink();
+    await expect(downloadFileStreaming('i1', meta(contentId), kek, sink))
+      .rejects.toThrow(/integrity/i);
+    expect(state.aborted).toBe(true);
+    expect(state.closed).toBe(false);
+  });
+
+  it('throws when the DEK cannot be unwrapped (wrong contentId binding)', async () => {
+    const object = await buildObject(new Uint8Array(4), crypto.randomUUID(), 4);
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, body: streamOf(object) })));
+    const { sink } = fakeSink();
+    await expect(downloadFileStreaming('i1', meta('wrong-content-id'), kek, sink)).rejects.toThrow();
+  });
+});

--- a/packages/web/src/items/streamingDownload.test.ts
+++ b/packages/web/src/items/streamingDownload.test.ts
@@ -7,7 +7,7 @@ import type { FileMetadata } from './metadata';
 const api = vi.hoisted(() => ({ getDownloadUrl: vi.fn(async () => 'https://s3/get') }));
 vi.mock('../api/items', () => api);
 
-import { downloadFileStreaming, type DownloadSink } from './streamingDownload';
+import { downloadFileStreaming, pickSink, type DownloadSink } from './streamingDownload';
 
 const kek = new Uint8Array(32).fill(7);
 
@@ -104,5 +104,33 @@ describe('downloadFileStreaming', () => {
     vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, body: streamOf(object) })));
     const { sink } = fakeSink();
     await expect(downloadFileStreaming('i1', meta('wrong-content-id'), kek, sink)).rejects.toThrow();
+  });
+});
+
+describe('pickSink capability detection', () => {
+  it('uses the File System Access API when available, streaming write→close', async () => {
+    const written: Uint8Array[] = [];
+    const writable = { write: vi.fn((b: Uint8Array) => { written.push(b); }), close: vi.fn(), abort: vi.fn() };
+    const handle = { createWritable: vi.fn(async () => writable) };
+    const showSaveFilePicker = vi.fn(async () => handle);
+    vi.stubGlobal('showSaveFilePicker', showSaveFilePicker);
+
+    const sink = await pickSink('photo.jpg', 'image/jpeg');
+    expect(showSaveFilePicker).toHaveBeenCalledWith({ suggestedName: 'photo.jpg' });
+    await sink.write(new Uint8Array([1, 2]));
+    await sink.close();
+    expect(written).toEqual([new Uint8Array([1, 2])]);
+    expect(writable.close).toHaveBeenCalled();
+  });
+
+  it('falls back to an in-memory blob when the API is absent', async () => {
+    vi.stubGlobal('showSaveFilePicker', undefined);
+    const createObjectURL = vi.fn(() => 'blob:x');
+    vi.stubGlobal('URL', { ...URL, createObjectURL, revokeObjectURL: vi.fn() });
+
+    const sink = await pickSink('a.bin', 'application/octet-stream');
+    sink.write(new Uint8Array([9]));
+    await sink.close(); // blob sink triggers an <a download> via an object URL
+    expect(createObjectURL).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/items/streamingDownload.ts
+++ b/packages/web/src/items/streamingDownload.ts
@@ -1,0 +1,133 @@
+import {
+  unwrapDek,
+  parseStreamHeader,
+  decryptChunk,
+  STREAM_HEADER_SIZE,
+  TAG_SIZE,
+} from '@cortex/encryption';
+import { WRAPPED_DEK_SIZE } from './itemBlob';
+import { type FileMetadata } from './metadata';
+import { getDownloadUrl } from '../api/items';
+
+const PREFIX_SIZE = WRAPPED_DEK_SIZE + STREAM_HEADER_SIZE; // 97 + 13 = 110
+
+export interface DownloadSink {
+  write(bytes: Uint8Array): void | Promise<void>;
+  close(): void | Promise<void>;
+  abort(): void | Promise<void>;
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+  let o = 0;
+  for (const p of parts) {
+    out.set(p, o);
+    o += p.length;
+  }
+  return out;
+}
+
+// --- tier 3: in-memory blob (works everywhere; not for multi-GB files) ---
+export function blobSink(name: string, contentType: string): DownloadSink {
+  const parts: Uint8Array[] = [];
+  return {
+    write(b) {
+      parts.push(b);
+    },
+    close() {
+      const url = URL.createObjectURL(new Blob(parts as BlobPart[], { type: contentType }));
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = name;
+      a.click();
+      URL.revokeObjectURL(url);
+    },
+    abort() {
+      parts.length = 0;
+    },
+  };
+}
+
+// Caller picks the sink BEFORE any other await (user-activation for showSaveFilePicker).
+// Task 2 prepends the File System Access tier ahead of the blob fallback.
+export async function pickSink(name: string, contentType: string): Promise<DownloadSink> {
+  return blobSink(name, contentType);
+}
+
+async function readExactly(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  n: number,
+): Promise<{ head: Uint8Array; rest: Uint8Array }> {
+  const bufs: Uint8Array[] = [];
+  let have = 0;
+  while (have < n) {
+    const { value, done } = await reader.read();
+    if (done) throw new Error('Stream ended before the stream header was read');
+    bufs.push(value);
+    have += value.length;
+  }
+  const all = concat(bufs);
+  return { head: all.slice(0, n), rest: all.slice(n) };
+}
+
+/**
+ * Stream-decrypt a chunked object straight to a sink.
+ *
+ * Reads the `wrappedDek(97)+header(13)` prefix off the response stream, unwraps
+ * the DEK, then frames the rest into `chunkSize+16` blocks. A block is emitted
+ * non-final only while strictly more than one block is buffered; whatever remains
+ * at EOF is decrypted with `isFinal=true` — so a dropped tail makes a non-final
+ * chunk read as final and fail authentication. Any decrypt failure discards the
+ * partial sink. Memory stays O(chunkSize).
+ */
+export async function downloadFileStreaming(
+  itemId: string,
+  meta: FileMetadata,
+  kek: Uint8Array,
+  sink: DownloadSink,
+): Promise<void> {
+  const url = await getDownloadUrl(itemId);
+  const res = await fetch(url);
+  if (!res.ok || !res.body) throw new Error(`Download failed: ${(res as Response).status ?? 'no body'}`);
+  const reader = res.body.getReader();
+
+  // Prefix: wrappedDek(97) + header(13). `rest` is the start of chunk 0.
+  const { head, rest } = await readExactly(reader, PREFIX_SIZE);
+  const wrappedDek = head.slice(0, WRAPPED_DEK_SIZE);
+  const header = head.slice(WRAPPED_DEK_SIZE);
+  const { chunkSize, noncePrefix } = parseStreamHeader(header);
+  const dek = unwrapDek(wrappedDek, kek, meta.contentId); // throws DekUnwrapError on wrong key/tamper
+
+  const blockSize = chunkSize + TAG_SIZE;
+  let buf = rest;
+  let index = 0;
+  // ponytail: one broad catch maps loop failures to the integrity message. The
+  // dominant failure here is a decryptChunk auth failure; a rare sink.write error
+  // (e.g. disk full) is mislabeled "integrity". Split the try if that matters.
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (value && value.length) buf = concat([buf, value]);
+      // Emit every block we KNOW is non-final: strictly more than one block buffered.
+      while (buf.length > blockSize) {
+        const block = buf.slice(0, blockSize);
+        buf = buf.slice(blockSize);
+        await sink.write(decryptChunk(block, {
+          dek, noncePrefix, index, isFinal: false, contentId: meta.contentId, header,
+        }));
+        index += 1;
+      }
+      if (done) break;
+    }
+    // Whatever remains is the final block (truncation makes a non-final chunk land here → reject).
+    await sink.write(decryptChunk(buf, {
+      dek, noncePrefix, index, isFinal: true, contentId: meta.contentId, header,
+    }));
+    await sink.close();
+  } catch {
+    await Promise.resolve(sink.abort()).catch(() => {});
+    throw new Error('File failed integrity check');
+  } finally {
+    dek.fill(0);
+  }
+}

--- a/packages/web/src/items/streamingDownload.ts
+++ b/packages/web/src/items/streamingDownload.ts
@@ -48,9 +48,34 @@ export function blobSink(name: string, contentType: string): DownloadSink {
   };
 }
 
+// --- tier 1: File System Access API — streams straight to the user's chosen file ---
+type SaveHandle = {
+  createWritable: () => Promise<{
+    write: (b: Uint8Array) => void | Promise<void>;
+    close: () => void | Promise<void>;
+    abort: () => void | Promise<void>;
+  }>;
+};
+type WithPicker = { showSaveFilePicker: (o: { suggestedName: string }) => Promise<SaveHandle> };
+
+async function fsAccessSink(name: string): Promise<DownloadSink> {
+  // Must be reached within the user gesture; the caller awaits pickSink first.
+  const handle = await (globalThis as unknown as WithPicker).showSaveFilePicker({ suggestedName: name });
+  const writable = await handle.createWritable();
+  return {
+    write: (b) => writable.write(b),
+    close: () => writable.close(),
+    abort: () => writable.abort(),
+  };
+}
+
 // Caller picks the sink BEFORE any other await (user-activation for showSaveFilePicker).
-// Task 2 prepends the File System Access tier ahead of the blob fallback.
 export async function pickSink(name: string, contentType: string): Promise<DownloadSink> {
+  // Tier 1: File System Access (true streaming to disk, Chromium desktop).
+  if (typeof (globalThis as { showSaveFilePicker?: unknown }).showSaveFilePicker === 'function') {
+    return fsAccessSink(name);
+  }
+  // Tier 3: in-memory blob fallback. (Tier 2 OPFS-in-Worker deferred — see plan.)
   return blobSink(name, contentType);
 }
 


### PR DESCRIPTION
## Phase B · Slice 2.5d — Streaming Download (frontend)

Replaces `FileList`'s whole-buffer download with a streaming chunked download. Consumes the 2.5a decrypt primitives; reads the format 2.5c (#215) writes. Completes the large-file streaming slice (2.5).

### What changed
- **`items/streamingDownload.ts`** (new) — `downloadFileStreaming(itemId, meta, kek, sink)`. Reads the `wrappedDek(97)+header(13)` prefix off `fetch().body` (a `ReadableStream`), unwraps the DEK (HMAC-bound to `contentId`), then frames the rest into `chunkSize+16` blocks and `decryptChunk`s each in order into a sink. Memory O(chunkSize).
  - **Sink interface** `{write, close, abort}` with two tiers: **File System Access** (`showSaveFilePicker` → `createWritable`, true streaming to the user's chosen file) and **in-memory blob** fallback. `pickSink` detects capability.
- **`components/FileList.tsx`** — `onDownload` dispatches on `meta.streamVersion`: present → pick sink + stream; absent → existing legacy whole-buffer path. Errors surface via the existing alert; user-cancel of the save dialog (`AbortError`) is silent.

### Integrity (untrusted S3)
- **Framing enforces truncation defense:** a block is emitted non-final only while strictly more than `chunkSize+16` bytes remain buffered; whatever's left at EOF is decrypted with `isFinal=true`. A dropped tail makes an `isFinal=false`-sealed chunk read as final → AAD mismatch → reject. Reorder/splice are caught the same way (index + `contentId` in AAD).
- Any chunk auth failure → `sink.abort()` (discard partial file) + "File failed integrity check".
- DEK zeroed in `finally`.

### User-activation ordering
`showSaveFilePicker()` needs live user activation, which any `await` consumes. `FileList.onDownload` calls `pickSink` as the **first** await off the Download click (streamVersion is already known from decrypted metadata — no await to branch), before `getVaultKeys`/`getDownloadUrl`.

### Tests
`npm --prefix packages/web test` → **69/69 green**; `tsc` + `vite build` clean. Round-trips empty / sub-chunk / exact-multiple / multi-chunk-remainder against real crypto; rejects tampered chunk and bad DEK binding; capability detection picks FS Access vs blob; FileList dispatches chunked vs legacy.

### Deferred (documented)
**OPFS-in-Worker sink (tier 2)** for streaming-to-disk on non-Chromium browsers. Without it, Firefox/Safari fall back to the in-memory blob (fine for normal files, not multi-GB). The `DownloadSink` seam + `pickSink` make it a drop-in third branch when a non-Chromium large-file download is actually needed.