### PR TITLE
feat(web): collections + tags (completes task 7)

### DIFF
--- a/packages/web/src/api/collections.test.ts
+++ b/packages/web/src/api/collections.test.ts
@@ -64,8 +64,8 @@ describe('collections api', () => {
   it('getCollection returns its items (or [])', async () => {
     const items = [{ itemId: 'i1', vaultId: 'v1', encryptedMetadata: new Uint8Array([1]), createdAt: new Date(0) }];
     sendMock.mockResolvedValueOnce({ collectionId: 'c1', items });
-    expect(await getCollection('c1')).toBe(items);
-    expect(commands).toContainEqual(['GetCollection', { collectionId: 'c1' }]);
+    expect(await getCollection('c1', 'v1')).toBe(items);
+    expect(commands).toContainEqual(['GetCollection', { collectionId: 'c1', vaultId: 'v1' }]);
   });
 
   it('add/remove/update/delete send the right inputs', async () => {

--- a/packages/web/src/api/collections.test.ts
+++ b/packages/web/src/api/collections.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { sendMock, commands } = vi.hoisted(() => ({ sendMock: vi.fn(), commands: [] as Array<[string, unknown]> }));
+
+vi.mock('@cortex/client', () => {
+  const cmd = (name: string) =>
+    class {
+      constructor(public input: unknown) {
+        commands.push([name, input]);
+      }
+    };
+  return {
+    CortexClient: class {
+      send = sendMock;
+      constructor(public config: unknown) {}
+    },
+    CreateCollectionCommand: cmd('CreateCollection'),
+    ListCollectionsCommand: cmd('ListCollections'),
+    GetCollectionCommand: cmd('GetCollection'),
+    UpdateCollectionCommand: cmd('UpdateCollection'),
+    DeleteCollectionCommand: cmd('DeleteCollection'),
+    AddItemToCollectionCommand: cmd('AddItemToCollection'),
+    RemoveItemFromCollectionCommand: cmd('RemoveItemFromCollection'),
+  };
+});
+vi.mock('aws-amplify/auth', () => ({
+  fetchAuthSession: vi.fn(async () => ({ tokens: { idToken: { toString: () => 'JWT' } } })),
+}));
+vi.mock('../config', () => ({ getConfig: () => ({ apiBaseUrl: 'https://api' }) }));
+
+import {
+  createCollection,
+  listCollections,
+  getCollection,
+  updateCollection,
+  deleteCollection,
+  addItemToCollection,
+  removeItemFromCollection,
+} from './collections';
+
+beforeEach(() => {
+  sendMock.mockReset();
+  commands.length = 0;
+});
+
+describe('collections api', () => {
+  it('createCollection returns the new id', async () => {
+    sendMock.mockResolvedValueOnce({ collectionId: 'c1', createdAt: new Date(0) });
+    const meta = new Uint8Array([1, 2]);
+    expect(await createCollection('v1', meta)).toBe('c1');
+    expect(commands).toContainEqual(['CreateCollection', { vaultId: 'v1', encryptedMetadata: meta }]);
+  });
+
+  it('listCollections returns the array (or [])', async () => {
+    const cols = [
+      { collectionId: 'c1', vaultId: 'v1', encryptedMetadata: new Uint8Array([9]), itemCount: 2, createdAt: new Date(0), updatedAt: new Date(0) },
+    ];
+    sendMock.mockResolvedValueOnce({ collections: cols });
+    expect(await listCollections('v1')).toBe(cols);
+    sendMock.mockResolvedValueOnce({});
+    expect(await listCollections('v1')).toEqual([]);
+  });
+
+  it('getCollection returns its items (or [])', async () => {
+    const items = [{ itemId: 'i1', vaultId: 'v1', encryptedMetadata: new Uint8Array([1]), createdAt: new Date(0) }];
+    sendMock.mockResolvedValueOnce({ collectionId: 'c1', items });
+    expect(await getCollection('c1')).toBe(items);
+    expect(commands).toContainEqual(['GetCollection', { collectionId: 'c1' }]);
+  });
+
+  it('add/remove/update/delete send the right inputs', async () => {
+    sendMock.mockResolvedValue({});
+    await addItemToCollection('c1', 'v1', 'i1');
+    await removeItemFromCollection('c1', 'v1', 'i1');
+    await updateCollection('c1', 'v1', new Uint8Array([7]));
+    await deleteCollection('c1', 'v1');
+    expect(commands).toContainEqual(['AddItemToCollection', { collectionId: 'c1', vaultId: 'v1', itemId: 'i1' }]);
+    expect(commands).toContainEqual(['RemoveItemFromCollection', { collectionId: 'c1', vaultId: 'v1', itemId: 'i1' }]);
+    expect(commands).toContainEqual(['UpdateCollection', { collectionId: 'c1', vaultId: 'v1', encryptedMetadata: new Uint8Array([7]) }]);
+    expect(commands).toContainEqual(['DeleteCollection', { collectionId: 'c1', vaultId: 'v1' }]);
+  });
+});

--- a/packages/web/src/api/collections.ts
+++ b/packages/web/src/api/collections.ts
@@ -21,8 +21,8 @@ export async function listCollections(vaultId: string): Promise<CollectionData[]
   return out.collections ?? [];
 }
 
-export async function getCollection(collectionId: string): Promise<ItemData[]> {
-  const out = await makeClient().send(new GetCollectionCommand({ collectionId }));
+export async function getCollection(collectionId: string, vaultId: string): Promise<ItemData[]> {
+  const out = await makeClient().send(new GetCollectionCommand({ collectionId, vaultId }));
   return out.items ?? [];
 }
 

--- a/packages/web/src/api/collections.ts
+++ b/packages/web/src/api/collections.ts
@@ -1,0 +1,51 @@
+import {
+  CreateCollectionCommand,
+  ListCollectionsCommand,
+  GetCollectionCommand,
+  UpdateCollectionCommand,
+  DeleteCollectionCommand,
+  AddItemToCollectionCommand,
+  RemoveItemFromCollectionCommand,
+} from '@cortex/client';
+import type { CollectionData, ItemData } from '@cortex/client';
+import { makeClient } from './client';
+
+export async function createCollection(vaultId: string, encryptedMetadata: Uint8Array): Promise<string> {
+  const out = await makeClient().send(new CreateCollectionCommand({ vaultId, encryptedMetadata }));
+  if (!out.collectionId) throw new Error('createCollection: incomplete response');
+  return out.collectionId;
+}
+
+export async function listCollections(vaultId: string): Promise<CollectionData[]> {
+  const out = await makeClient().send(new ListCollectionsCommand({ vaultId }));
+  return out.collections ?? [];
+}
+
+export async function getCollection(collectionId: string): Promise<ItemData[]> {
+  const out = await makeClient().send(new GetCollectionCommand({ collectionId }));
+  return out.items ?? [];
+}
+
+export async function updateCollection(
+  collectionId: string,
+  vaultId: string,
+  encryptedMetadata: Uint8Array,
+): Promise<void> {
+  await makeClient().send(new UpdateCollectionCommand({ collectionId, vaultId, encryptedMetadata }));
+}
+
+export async function deleteCollection(collectionId: string, vaultId: string): Promise<void> {
+  await makeClient().send(new DeleteCollectionCommand({ collectionId, vaultId }));
+}
+
+export async function addItemToCollection(collectionId: string, vaultId: string, itemId: string): Promise<void> {
+  await makeClient().send(new AddItemToCollectionCommand({ collectionId, vaultId, itemId }));
+}
+
+export async function removeItemFromCollection(
+  collectionId: string,
+  vaultId: string,
+  itemId: string,
+): Promise<void> {
+  await makeClient().send(new RemoveItemFromCollectionCommand({ collectionId, vaultId, itemId }));
+}

--- a/packages/web/src/api/items.test.ts
+++ b/packages/web/src/api/items.test.ts
@@ -34,6 +34,9 @@ vi.mock('@cortex/client', () => ({
   AbortItemUploadCommand: class {
     constructor(public input: unknown) { commands.push(['AbortItemUpload', input]); }
   },
+  SearchByTagCommand: class {
+    constructor(public input: unknown) { commands.push(['SearchByTag', input]); }
+  },
 }));
 vi.mock('aws-amplify/auth', () => ({
   fetchAuthSession: vi.fn(async () => ({ tokens: { idToken: { toString: () => 'JWT' } } })),
@@ -46,6 +49,7 @@ import {
   completeUpload,
   createUploadPartUrls,
   abortUpload,
+  searchByTag,
   listItems,
   getDownloadUrl,
   deleteItem,
@@ -145,6 +149,13 @@ describe('items api', () => {
     sendMock.mockResolvedValueOnce({ downloadUrl: 'https://s3/get', expiresAt: new Date(0) });
     expect(await getDownloadUrl('i1')).toBe('https://s3/get');
     expect(commands).toContainEqual(['GetItemDownloadUrl', { itemId: 'i1' }]);
+  });
+
+  it('searchByTag returns items (or [])', async () => {
+    const items = [{ itemId: 'i1', vaultId: 'v1', encryptedMetadata: new Uint8Array([1]), createdAt: new Date(0) }];
+    sendMock.mockResolvedValueOnce({ items, totalCount: 1 });
+    expect(await searchByTag('v1', 'YWJj')).toBe(items);
+    expect(commands).toContainEqual(['SearchByTag', { vaultId: 'v1', encryptedTag: 'YWJj' }]);
   });
 
   it('deleteItem sends the command with the itemId', async () => {

--- a/packages/web/src/api/items.ts
+++ b/packages/web/src/api/items.ts
@@ -17,6 +17,7 @@ export async function initiateUpload(args: {
   vaultId: string;
   encryptedMetadata: Uint8Array;
   sizeBytes: number;
+  encryptedTags?: Uint8Array[];
 }): Promise<{ itemId: string; uploadUrl: string; uploadId?: string }> {
   const out = await makeClient().send(new InitiateItemUploadCommand(args));
   if (!out.itemId || !out.uploadUrl) throw new Error('initiateUpload: incomplete response');

--- a/packages/web/src/api/items.ts
+++ b/packages/web/src/api/items.ts
@@ -6,6 +6,7 @@ import {
   ListItemsCommand,
   GetItemDownloadUrlCommand,
   DeleteItemCommand,
+  SearchByTagCommand,
 } from '@cortex/client';
 import type { ItemData } from '@cortex/client';
 import { makeClient } from './client';
@@ -69,6 +70,11 @@ export async function abortUpload(itemId: string, uploadId: string): Promise<voi
 
 export async function listItems(vaultId: string): Promise<ItemData[]> {
   const out = await makeClient().send(new ListItemsCommand({ vaultId }));
+  return out.items ?? [];
+}
+
+export async function searchByTag(vaultId: string, encryptedTag: string): Promise<ItemData[]> {
+  const out = await makeClient().send(new SearchByTagCommand({ vaultId, encryptedTag }));
   return out.items ?? [];
 }
 

--- a/packages/web/src/components/CollectionSidebar.test.tsx
+++ b/packages/web/src/components/CollectionSidebar.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const h = vi.hoisted(() => ({
+  getVaultKeys: vi.fn(async () => ({ vaultId: 'v1', kek: new Uint8Array(32), metadataKey: new Uint8Array(32) })),
+  listCollections: vi.fn(async () => [
+    { collectionId: 'c1', vaultId: 'v1', encryptedMetadata: new Uint8Array([1]), itemCount: 2, createdAt: new Date(0), updatedAt: new Date(0) },
+  ]),
+  createCollection: vi.fn(async () => 'c2'),
+  deleteCollection: vi.fn(async () => {}),
+  encryptCollectionName: vi.fn(async () => new Uint8Array([9])),
+  decryptCollectionName: vi.fn(() => 'Trip 2026'),
+}));
+vi.mock('../vault/keyAccess', () => ({ getVaultKeys: h.getVaultKeys }));
+vi.mock('../api/collections', () => ({
+  listCollections: h.listCollections,
+  createCollection: h.createCollection,
+  deleteCollection: h.deleteCollection,
+  updateCollection: vi.fn(),
+}));
+vi.mock('../items/collectionMetadata', () => ({
+  encryptCollectionName: h.encryptCollectionName,
+  decryptCollectionName: h.decryptCollectionName,
+}));
+
+import CollectionSidebar from './CollectionSidebar';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('CollectionSidebar', () => {
+  it('lists decrypted collection names with an All files entry', async () => {
+    render(<CollectionSidebar selected={{ kind: 'all' }} onSelect={vi.fn()} refreshKey={0} />);
+    expect(await screen.findByText('Trip 2026')).toBeInTheDocument();
+    expect(screen.getByText(/all files/i)).toBeInTheDocument();
+  });
+
+  it('selecting a collection calls onSelect with its id+name', async () => {
+    const onSelect = vi.fn();
+    render(<CollectionSidebar selected={{ kind: 'all' }} onSelect={onSelect} refreshKey={0} />);
+    await userEvent.click(await screen.findByText('Trip 2026'));
+    expect(onSelect).toHaveBeenCalledWith({ kind: 'collection', id: 'c1', name: 'Trip 2026' });
+  });
+
+  it('creating a collection encrypts the name and calls the API', async () => {
+    vi.spyOn(window, 'prompt').mockReturnValue('Receipts');
+    render(<CollectionSidebar selected={{ kind: 'all' }} onSelect={vi.fn()} refreshKey={0} />);
+    await userEvent.click(await screen.findByRole('button', { name: /new collection/i }));
+    await waitFor(() => expect(h.createCollection).toHaveBeenCalledWith('v1', expect.any(Uint8Array)));
+    expect(h.encryptCollectionName).toHaveBeenCalledWith('Receipts', expect.any(Uint8Array));
+  });
+});

--- a/packages/web/src/components/CollectionSidebar.tsx
+++ b/packages/web/src/components/CollectionSidebar.tsx
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useState } from 'react';
+import { getVaultKeys } from '../vault/keyAccess';
+import { listCollections, createCollection, deleteCollection } from '../api/collections';
+import { encryptCollectionName, decryptCollectionName } from '../items/collectionMetadata';
+
+export type View =
+  | { kind: 'all' }
+  | { kind: 'collection'; id: string; name: string }
+  | { kind: 'tag'; encryptedTag: string; label: string };
+
+type Row = { id: string; name: string };
+
+export default function CollectionSidebar({
+  selected,
+  onSelect,
+  refreshKey,
+  onChanged,
+}: {
+  selected: View;
+  onSelect: (v: View) => void;
+  refreshKey: number;
+  onChanged?: () => void;
+}) {
+  const [rows, setRows] = useState<Row[]>([]);
+  const [error, setError] = useState('');
+
+  const load = useCallback(async () => {
+    setError('');
+    try {
+      const { vaultId, metadataKey } = await getVaultKeys();
+      const cols = await listCollections(vaultId);
+      setRows(
+        cols.map((c) => ({
+          id: c.collectionId!,
+          name: c.encryptedMetadata ? safeName(c.encryptedMetadata, metadataKey) : '(unreadable)',
+        })),
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not load collections');
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load, refreshKey]);
+
+  async function onCreate() {
+    const name = window.prompt('Collection name')?.trim();
+    if (!name) return;
+    const { vaultId, metadataKey } = await getVaultKeys();
+    await createCollection(vaultId, await encryptCollectionName(name, metadataKey));
+    await load();
+    onChanged?.();
+  }
+
+  async function onDelete(id: string) {
+    const { vaultId } = await getVaultKeys();
+    await deleteCollection(id, vaultId);
+    if (selected.kind === 'collection' && selected.id === id) onSelect({ kind: 'all' });
+    await load();
+    onChanged?.();
+  }
+
+  return (
+    <nav aria-label="collections">
+      <button onClick={() => onSelect({ kind: 'all' })} aria-current={selected.kind === 'all'}>
+        All files
+      </button>
+      <ul>
+        {rows.map((r) => (
+          <li key={r.id}>
+            <button
+              onClick={() => onSelect({ kind: 'collection', id: r.id, name: r.name })}
+              aria-current={selected.kind === 'collection' && selected.id === r.id}
+            >
+              {r.name}
+            </button>
+            <button aria-label={`delete ${r.name}`} onClick={() => onDelete(r.id)}>
+              ×
+            </button>
+          </li>
+        ))}
+      </ul>
+      <button onClick={onCreate}>+ New collection</button>
+      {error && <p role="alert">{error}</p>}
+    </nav>
+  );
+}
+
+function safeName(blob: Uint8Array, metadataKey: Uint8Array): string {
+  try {
+    return decryptCollectionName(blob, metadataKey);
+  } catch {
+    return '(unreadable)';
+  }
+}

--- a/packages/web/src/components/Dashboard.test.tsx
+++ b/packages/web/src/components/Dashboard.test.tsx
@@ -4,13 +4,17 @@ import { render, screen } from '@testing-library/react';
 vi.mock('../auth/SessionContext', () => ({ useSession: () => ({ logout: vi.fn() }) }));
 vi.mock('./FileUpload', () => ({ default: () => <div>file-upload</div>, MAX_FILE_SIZE_BYTES: 1 }));
 vi.mock('./FileList', () => ({ default: ({ refreshKey }: { refreshKey: number }) => <div>file-list:{refreshKey}</div> }));
+vi.mock('./CollectionSidebar', () => ({ default: () => <div>sidebar</div> }));
+vi.mock('./TagSearch', () => ({ default: () => <div>tag-search</div> }));
 
 import Dashboard from './Dashboard';
 
 describe('Dashboard', () => {
-  it('shows the upload control and the file list', () => {
+  it('shows the sidebar, upload control, tag search, and file list', () => {
     render(<Dashboard />);
+    expect(screen.getByText('sidebar')).toBeInTheDocument();
     expect(screen.getByText('file-upload')).toBeInTheDocument();
+    expect(screen.getByText('tag-search')).toBeInTheDocument();
     expect(screen.getByText(/file-list:/)).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -2,17 +2,25 @@ import { useState } from 'react';
 import { useSession } from '../auth/SessionContext';
 import FileUpload from './FileUpload';
 import FileList from './FileList';
+import CollectionSidebar, { type View } from './CollectionSidebar';
+import TagSearch from './TagSearch';
 
 export default function Dashboard() {
   const { logout } = useSession();
   const [refreshKey, setRefreshKey] = useState(0);
+  const [view, setView] = useState<View>({ kind: 'all' });
+  const bump = () => setRefreshKey((k) => k + 1);
 
   return (
-    <div style={{ padding: '2rem' }}>
-      <h1>Dashboard</h1>
-      <FileUpload onUploaded={() => setRefreshKey((k) => k + 1)} />
-      <FileList refreshKey={refreshKey} />
-      <button onClick={() => logout()}>Log out</button>
+    <div style={{ padding: '2rem', display: 'flex', gap: '2rem' }}>
+      <CollectionSidebar selected={view} onSelect={setView} refreshKey={refreshKey} onChanged={bump} />
+      <div style={{ flex: 1 }}>
+        <h1>Dashboard</h1>
+        <FileUpload onUploaded={bump} />
+        <TagSearch onSearch={setView} onClear={() => setView({ kind: 'all' })} />
+        <FileList view={view} refreshKey={refreshKey} />
+        <button onClick={() => logout()}>Log out</button>
+      </div>
     </div>
   );
 }

--- a/packages/web/src/components/FileList.test.tsx
+++ b/packages/web/src/components/FileList.test.tsx
@@ -10,7 +10,7 @@ const h = vi.hoisted(() => ({
   deleteItem: vi.fn(async () => {}),
   searchByTag: vi.fn(async () => [{ itemId: 'i1', encryptedMetadata: new Uint8Array([1]), createdAt: new Date(1000) }]),
   getCollection: vi.fn(async () => [{ itemId: 'i1', encryptedMetadata: new Uint8Array([1]), createdAt: new Date(1000) }]),
-  listCollections: vi.fn(async () => []),
+  listCollections: vi.fn(async (): Promise<import('@cortex/client').CollectionData[]> => []),
   addItemToCollection: vi.fn(async () => {}),
   decryptMetadata: vi.fn((): FileMetadata => ({ name: 'cat.png', contentType: 'image/png', size: 1234, contentId: 'c1' })),
   decryptDownloadedBlob: vi.fn(() => new Uint8Array([1, 2, 3])),
@@ -60,7 +60,7 @@ describe('FileList', () => {
 
   it('a collection view loads via getCollection, not listItems', async () => {
     render(<FileList view={{ kind: 'collection', id: 'c1', name: 'Trip' }} refreshKey={0} />);
-    await waitFor(() => expect(h.getCollection).toHaveBeenCalledWith('c1'));
+    await waitFor(() => expect(h.getCollection).toHaveBeenCalledWith('c1', 'v1'));
     expect(h.listItems).not.toHaveBeenCalled();
   });
 

--- a/packages/web/src/components/FileList.test.tsx
+++ b/packages/web/src/components/FileList.test.tsx
@@ -8,62 +8,99 @@ const h = vi.hoisted(() => ({
   listItems: vi.fn(async () => [{ itemId: 'i1', encryptedMetadata: new Uint8Array([1]), createdAt: new Date(1000) }]),
   getDownloadUrl: vi.fn(async () => 'https://s3/get'),
   deleteItem: vi.fn(async () => {}),
+  searchByTag: vi.fn(async () => [{ itemId: 'i1', encryptedMetadata: new Uint8Array([1]), createdAt: new Date(1000) }]),
+  getCollection: vi.fn(async () => [{ itemId: 'i1', encryptedMetadata: new Uint8Array([1]), createdAt: new Date(1000) }]),
+  listCollections: vi.fn(async () => []),
+  addItemToCollection: vi.fn(async () => {}),
   decryptMetadata: vi.fn((): FileMetadata => ({ name: 'cat.png', contentType: 'image/png', size: 1234, contentId: 'c1' })),
   decryptDownloadedBlob: vi.fn(() => new Uint8Array([1, 2, 3])),
+  decryptCollectionName: vi.fn(() => 'Trip'),
   pickSink: vi.fn(async () => ({ write: vi.fn(), close: vi.fn(), abort: vi.fn() })),
   downloadFileStreaming: vi.fn(async () => {}),
 }));
 vi.mock('../vault/keyAccess', () => ({ getVaultKeys: h.getVaultKeys }));
-vi.mock('../api/items', () => ({ listItems: h.listItems, getDownloadUrl: h.getDownloadUrl, deleteItem: h.deleteItem }));
+vi.mock('../api/items', () => ({
+  listItems: h.listItems,
+  getDownloadUrl: h.getDownloadUrl,
+  deleteItem: h.deleteItem,
+  searchByTag: h.searchByTag,
+}));
+vi.mock('../api/collections', () => ({
+  getCollection: h.getCollection,
+  listCollections: h.listCollections,
+  addItemToCollection: h.addItemToCollection,
+}));
 vi.mock('../items/metadata', () => ({ decryptMetadata: h.decryptMetadata }));
 vi.mock('../items/itemCrypto', () => ({ decryptDownloadedBlob: h.decryptDownloadedBlob }));
+vi.mock('../items/collectionMetadata', () => ({ decryptCollectionName: h.decryptCollectionName }));
 vi.mock('../items/streamingDownload', () => ({ pickSink: h.pickSink, downloadFileStreaming: h.downloadFileStreaming }));
 
 import FileList from './FileList';
 
+const ALL = { kind: 'all' as const };
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.stubGlobal('fetch', vi.fn(async () => new Response(new Uint8Array([9]).buffer)));
-  // jsdom lacks these; stub so the download path doesn't crash.
   vi.stubGlobal('URL', { ...URL, createObjectURL: vi.fn(() => 'blob:x'), revokeObjectURL: vi.fn() });
 });
 
 describe('FileList', () => {
   it('renders a decrypted row', async () => {
-    render(<FileList refreshKey={0} />);
+    render(<FileList view={ALL} refreshKey={0} />);
     expect(await screen.findByText('cat.png')).toBeInTheDocument();
   });
 
+  it('renders tag chips from decrypted metadata', async () => {
+    h.decryptMetadata.mockReturnValueOnce({ name: 'cat.png', contentType: 'image/png', size: 1, contentId: 'c1', tags: ['beach', 'trip'] });
+    render(<FileList view={ALL} refreshKey={0} />);
+    expect(await screen.findByText(/beach/)).toBeInTheDocument();
+    expect(screen.getByText(/trip/)).toBeInTheDocument();
+  });
+
+  it('a collection view loads via getCollection, not listItems', async () => {
+    render(<FileList view={{ kind: 'collection', id: 'c1', name: 'Trip' }} refreshKey={0} />);
+    await waitFor(() => expect(h.getCollection).toHaveBeenCalledWith('c1'));
+    expect(h.listItems).not.toHaveBeenCalled();
+  });
+
+  it('a tag view loads via searchByTag', async () => {
+    render(<FileList view={{ kind: 'tag', encryptedTag: 'YWJj', label: 'beach' }} refreshKey={0} />);
+    await waitFor(() => expect(h.searchByTag).toHaveBeenCalledWith('v1', 'YWJj'));
+  });
+
   it('legacy download (no streamVersion) fetches the url, decrypts whole-buffer, saves', async () => {
-    render(<FileList refreshKey={0} />);
+    render(<FileList view={ALL} refreshKey={0} />);
     await screen.findByText('cat.png');
-    await userEvent.click(screen.getByRole('button', { name: /download/i }));
+    await userEvent.click(screen.getByRole('button', { name: /^download$/i }));
     await waitFor(() => expect(h.getDownloadUrl).toHaveBeenCalledWith('i1'));
     expect(h.decryptDownloadedBlob).toHaveBeenCalled();
     expect(h.downloadFileStreaming).not.toHaveBeenCalled();
   });
 
   it('chunked download (streamVersion present) picks a sink and streams', async () => {
-    // Once only — clearAllMocks doesn't restore an overridden implementation, so a
-    // persistent mockReturnValue would leak streamVersion into later tests.
-    h.decryptMetadata.mockReturnValueOnce({
-      name: 'big.bin', contentType: 'application/octet-stream', size: 999, contentId: 'c2', streamVersion: 1,
-    });
-    render(<FileList refreshKey={0} />);
+    h.decryptMetadata.mockReturnValueOnce({ name: 'big.bin', contentType: 'application/octet-stream', size: 999, contentId: 'c2', streamVersion: 1 });
+    render(<FileList view={ALL} refreshKey={0} />);
     await screen.findByText('big.bin');
-    await userEvent.click(screen.getByRole('button', { name: /download/i }));
+    await userEvent.click(screen.getByRole('button', { name: /^download$/i }));
     await waitFor(() => expect(h.pickSink).toHaveBeenCalledWith('big.bin', 'application/octet-stream'));
-    expect(h.downloadFileStreaming).toHaveBeenCalledWith(
-      'i1',
-      expect.objectContaining({ streamVersion: 1 }),
-      expect.any(Uint8Array),
-      expect.anything(),
-    );
+    expect(h.downloadFileStreaming).toHaveBeenCalledWith('i1', expect.objectContaining({ streamVersion: 1 }), expect.any(Uint8Array), expect.anything());
     expect(h.decryptDownloadedBlob).not.toHaveBeenCalled();
   });
 
+  it('add-to-collection lists collections then adds the item', async () => {
+    h.listCollections.mockResolvedValueOnce([
+      { collectionId: 'c9', vaultId: 'v1', encryptedMetadata: new Uint8Array([1]), itemCount: 0, createdAt: new Date(0), updatedAt: new Date(0) },
+    ]);
+    render(<FileList view={ALL} refreshKey={0} />);
+    await screen.findByText('cat.png');
+    await userEvent.click(screen.getByRole('button', { name: /add to collection/i }));
+    await userEvent.click(await screen.findByRole('menuitem', { name: 'Trip' }));
+    await waitFor(() => expect(h.addItemToCollection).toHaveBeenCalledWith('c9', 'v1', 'i1'));
+  });
+
   it('delete calls the API then reloads the list', async () => {
-    render(<FileList refreshKey={0} />);
+    render(<FileList view={ALL} refreshKey={0} />);
     await screen.findByText('cat.png');
     await userEvent.click(screen.getByRole('button', { name: /delete/i }));
     await waitFor(() => expect(h.deleteItem).toHaveBeenCalledWith('i1'));

--- a/packages/web/src/components/FileList.tsx
+++ b/packages/web/src/components/FileList.tsx
@@ -25,7 +25,7 @@ export default function FileList({ view, refreshKey }: { view: View; refreshKey:
       // All three sources return ItemData[]; the view picks which.
       const items =
         view.kind === 'collection'
-          ? await getCollection(view.id)
+          ? await getCollection(view.id, vaultId)
           : view.kind === 'tag'
             ? await searchByTag(vaultId, view.encryptedTag)
             : await listItems(vaultId);

--- a/packages/web/src/components/FileList.tsx
+++ b/packages/web/src/components/FileList.tsx
@@ -1,17 +1,20 @@
 import { useCallback, useEffect, useState } from 'react';
 import { getVaultKeys } from '../vault/keyAccess';
-import { listItems, getDownloadUrl, deleteItem } from '../api/items';
+import { listItems, getDownloadUrl, deleteItem, searchByTag } from '../api/items';
+import { getCollection, listCollections, addItemToCollection } from '../api/collections';
 import { decryptMetadata, type FileMetadata } from '../items/metadata';
 import { decryptDownloadedBlob } from '../items/itemCrypto';
+import { decryptCollectionName } from '../items/collectionMetadata';
 import { pickSink, downloadFileStreaming } from '../items/streamingDownload';
+import type { View } from './CollectionSidebar';
 
 interface Row {
   itemId: string;
-  createdAt?: Date; // generated ItemData.createdAt is a Date (not epoch seconds)
+  createdAt?: Date;
   meta: FileMetadata | null; // null = metadata failed to decrypt
 }
 
-export default function FileList({ refreshKey }: { refreshKey: number }) {
+export default function FileList({ view, refreshKey }: { view: View; refreshKey: number }) {
   const [rows, setRows] = useState<Row[]>([]);
   const [error, setError] = useState('');
 
@@ -19,7 +22,13 @@ export default function FileList({ refreshKey }: { refreshKey: number }) {
     setError('');
     try {
       const { vaultId, metadataKey } = await getVaultKeys();
-      const items = await listItems(vaultId);
+      // All three sources return ItemData[]; the view picks which.
+      const items =
+        view.kind === 'collection'
+          ? await getCollection(view.id)
+          : view.kind === 'tag'
+            ? await searchByTag(vaultId, view.encryptedTag)
+            : await listItems(vaultId);
       setRows(
         items.map((it) => {
           let meta: FileMetadata | null = null;
@@ -34,7 +43,7 @@ export default function FileList({ refreshKey }: { refreshKey: number }) {
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Could not load files');
     }
-  }, []);
+  }, [view]);
 
   useEffect(() => {
     void load();
@@ -84,11 +93,62 @@ export default function FileList({ refreshKey }: { refreshKey: number }) {
         <li key={row.itemId}>
           <span>{row.meta ? row.meta.name : '(unreadable)'}</span>
           {row.meta && <span> · {row.meta.size} bytes</span>}
+          {row.meta?.tags?.map((t) => (
+            <span key={t} className="tag-chip"> #{t}</span>
+          ))}
           {row.createdAt && <span> · {row.createdAt.toLocaleDateString()}</span>}
           <button onClick={() => onDownload(row)} disabled={!row.meta}>Download</button>
           <button onClick={() => onDelete(row.itemId)}>Delete</button>
+          {row.meta && <AddToCollection itemId={row.itemId} onChanged={load} />}
         </li>
       ))}
     </ul>
   );
+}
+
+function AddToCollection({ itemId, onChanged }: { itemId: string; onChanged: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [cols, setCols] = useState<{ id: string; name: string }[]>([]);
+
+  async function openMenu() {
+    const { vaultId, metadataKey } = await getVaultKeys();
+    const list = await listCollections(vaultId);
+    setCols(
+      list.map((c) => ({
+        id: c.collectionId!,
+        name: c.encryptedMetadata ? tryName(c.encryptedMetadata, metadataKey) : '(unreadable)',
+      })),
+    );
+    setOpen(true);
+  }
+
+  async function add(collectionId: string) {
+    const { vaultId } = await getVaultKeys();
+    await addItemToCollection(collectionId, vaultId, itemId);
+    setOpen(false);
+    onChanged();
+  }
+
+  return (
+    <span>
+      <button onClick={openMenu}>Add to collection</button>
+      {open && (
+        <ul role="menu">
+          {cols.map((c) => (
+            <li key={c.id}>
+              <button role="menuitem" onClick={() => add(c.id)}>{c.name}</button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </span>
+  );
+}
+
+function tryName(blob: Uint8Array, metadataKey: Uint8Array): string {
+  try {
+    return decryptCollectionName(blob, metadataKey);
+  } catch {
+    return '(unreadable)';
+  }
 }

--- a/packages/web/src/components/FileUpload.test.tsx
+++ b/packages/web/src/components/FileUpload.test.tsx
@@ -30,7 +30,16 @@ describe('FileUpload', () => {
       expect.objectContaining({ name: 'a.png' }),
       expect.objectContaining({ vaultId: 'v1' }),
       expect.any(Function),
+      expect.objectContaining({ tags: expect.any(Array) }),
     );
+  });
+
+  it('passes parsed tags from the tags input', async () => {
+    render(<FileUpload onUploaded={vi.fn()} />);
+    await userEvent.type(screen.getByLabelText(/tags/i), 'Trip, beach ,');
+    await userEvent.upload(screen.getByLabelText(/upload/i), pick('a.png', 3));
+    await waitFor(() => expect(h.uploadFileStreaming).toHaveBeenCalled());
+    expect(h.uploadFileStreaming.mock.calls[0][3]).toEqual({ tags: ['Trip', 'beach'] });
   });
 
   it('rejects files over the 5 GB cap without uploading', async () => {

--- a/packages/web/src/components/FileUpload.test.tsx
+++ b/packages/web/src/components/FileUpload.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 
 const h = vi.hoisted(() => ({
   getVaultKeys: vi.fn(async () => ({ vaultId: 'v1', kek: new Uint8Array(32), metadataKey: new Uint8Array(32) })),
-  uploadFileStreaming: vi.fn(async () => {}),
+  uploadFileStreaming: vi.fn(async (..._args: unknown[]) => {}),
 }));
 vi.mock('../vault/keyAccess', () => ({ getVaultKeys: h.getVaultKeys }));
 vi.mock('../items/streamingUpload', () => ({ uploadFileStreaming: h.uploadFileStreaming }));

--- a/packages/web/src/components/FileUpload.tsx
+++ b/packages/web/src/components/FileUpload.tsx
@@ -9,6 +9,7 @@ export const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024 * 1024;
 export default function FileUpload({ onUploaded }: { onUploaded: () => void }) {
   const [busy, setBusy] = useState(false);
   const [progress, setProgress] = useState(0);
+  const [tags, setTags] = useState('');
   const [error, setError] = useState('');
 
   async function onChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -24,7 +25,10 @@ export default function FileUpload({ onUploaded }: { onUploaded: () => void }) {
     setProgress(0);
     try {
       const keys = await getVaultKeys();
-      await uploadFileStreaming(file, keys, setProgress);
+      await uploadFileStreaming(file, keys, setProgress, {
+        tags: tags.split(',').map((t) => t.trim()).filter(Boolean),
+      });
+      setTags('');
       onUploaded();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Upload failed');
@@ -35,6 +39,14 @@ export default function FileUpload({ onUploaded }: { onUploaded: () => void }) {
 
   return (
     <div>
+      <input
+        type="text"
+        aria-label="tags"
+        placeholder="tags, comma separated"
+        value={tags}
+        onChange={(e) => setTags(e.target.value)}
+        disabled={busy}
+      />
       <label>
         Upload file
         <input type="file" onChange={onChange} disabled={busy} />

--- a/packages/web/src/components/TagSearch.test.tsx
+++ b/packages/web/src/components/TagSearch.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const h = vi.hoisted(() => ({
+  getVaultKeys: vi.fn(async () => ({ vaultId: 'v1', kek: new Uint8Array(32), metadataKey: new Uint8Array(32) })),
+}));
+vi.mock('../vault/keyAccess', () => ({ getVaultKeys: h.getVaultKeys }));
+
+import TagSearch from './TagSearch';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('TagSearch', () => {
+  it('encrypts the query and emits a tag view', async () => {
+    const onSearch = vi.fn();
+    render(<TagSearch onSearch={onSearch} onClear={vi.fn()} />);
+    await userEvent.type(screen.getByLabelText(/search tag/i), 'Beach');
+    await userEvent.click(screen.getByRole('button', { name: /search/i }));
+    await waitFor(() => expect(onSearch).toHaveBeenCalled());
+    const view = onSearch.mock.calls[0][0];
+    expect(view.kind).toBe('tag');
+    expect(view.label).toBe('Beach');
+    expect(typeof view.encryptedTag).toBe('string'); // base64
+  });
+
+  it('clear resets and emits onClear', async () => {
+    const onClear = vi.fn();
+    render(<TagSearch onSearch={vi.fn()} onClear={onClear} />);
+    await userEvent.click(screen.getByRole('button', { name: /clear/i }));
+    expect(onClear).toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/components/TagSearch.tsx
+++ b/packages/web/src/components/TagSearch.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { encryptTagForSearch, bytesToBase64 } from '@cortex/encryption';
+import { getVaultKeys } from '../vault/keyAccess';
+import type { View } from './CollectionSidebar';
+
+export default function TagSearch({
+  onSearch,
+  onClear,
+}: {
+  onSearch: (v: View) => void;
+  onClear: () => void;
+}) {
+  const [q, setQ] = useState('');
+
+  async function search() {
+    const tag = q.trim();
+    if (!tag) return;
+    // Same key + vaultId as the upload path so the HMACs match server-side.
+    const { vaultId, metadataKey } = await getVaultKeys();
+    const encryptedTag = bytesToBase64(encryptTagForSearch(tag, metadataKey, vaultId));
+    onSearch({ kind: 'tag', encryptedTag, label: tag });
+  }
+
+  return (
+    <div>
+      <input
+        aria-label="search tag"
+        value={q}
+        placeholder="search by tag"
+        onChange={(e) => setQ(e.target.value)}
+      />
+      <button onClick={search}>Search</button>
+      <button
+        onClick={() => {
+          setQ('');
+          onClear();
+        }}
+      >
+        Clear
+      </button>
+    </div>
+  );
+}

--- a/packages/web/src/items/collectionMetadata.test.ts
+++ b/packages/web/src/items/collectionMetadata.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { deriveKeys } from '@cortex/encryption';
+import { encryptCollectionName, decryptCollectionName } from './collectionMetadata';
+
+const metadataKey = deriveKeys(new Uint8Array(32).fill(3)).metadataEncryptionKey;
+
+describe('collectionMetadata', () => {
+  it('round-trips a collection name', async () => {
+    const blob = await encryptCollectionName('Trip 2026 🌍', metadataKey);
+    expect(decryptCollectionName(blob, metadataKey)).toBe('Trip 2026 🌍');
+  });
+
+  it('produces opaque ciphertext (name not in plaintext)', async () => {
+    const blob = await encryptCollectionName('Receipts', metadataKey);
+    expect(new TextDecoder().decode(blob)).not.toContain('Receipts');
+  });
+});

--- a/packages/web/src/items/collectionMetadata.ts
+++ b/packages/web/src/items/collectionMetadata.ts
@@ -1,0 +1,11 @@
+import { encrypt, decrypt, stringToBytes, bytesToString } from '@cortex/encryption';
+
+// A collection's only metadata today is its name. Encrypted with the vault's
+// metadataKey (reversible) so the sidebar can display it. Server stores opaque bytes.
+export async function encryptCollectionName(name: string, metadataKey: Uint8Array): Promise<Uint8Array> {
+  return encrypt(stringToBytes(JSON.stringify({ name })), metadataKey);
+}
+
+export function decryptCollectionName(blob: Uint8Array, metadataKey: Uint8Array): string {
+  return (JSON.parse(bytesToString(decrypt(blob, metadataKey))) as { name: string }).name;
+}

--- a/packages/web/src/items/metadata.ts
+++ b/packages/web/src/items/metadata.ts
@@ -8,6 +8,9 @@ export interface FileMetadata {
   // Set to STREAM_VERSION for chunked-stream uploads (2.5c). Absent ⇒ legacy
   // Slice 2 whole-buffer object; the download path dispatches on this.
   streamVersion?: number;
+  // Readable tags (chips). The searchable form is the one-way HMAC encryptedTags
+  // on the item; this plaintext copy lives here so the UI can display them.
+  tags?: string[];
 }
 
 // Adapted for #208: the Smithy `encryptedMetadata` field is a Blob (Uint8Array)

--- a/packages/web/src/items/streamingUpload.test.ts
+++ b/packages/web/src/items/streamingUpload.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { encryptTagForSearch } from '@cortex/encryption';
 import { decryptMetadata } from './metadata';
 
 const api = vi.hoisted(() => ({
@@ -51,6 +52,18 @@ describe('uploadFileStreaming', () => {
     expect(api.putToS3.mock.calls[0][1].length).toBe(129);
     expect(api.completeUpload).toHaveBeenCalledWith('i1'); // no opts
     expect(onProgress).toHaveBeenLastCalledWith(1);
+  });
+
+  it('dual-writes tags: plaintext in metadata, HMAC in encryptedTags', async () => {
+    api.initiateUpload.mockResolvedValue({ itemId: 'i1', uploadUrl: 'https://s3/put' });
+    await uploadFileStreaming(fakeFile(new Uint8Array([1, 2, 3])), keys, undefined, { tags: ['Trip', 'beach'] });
+
+    const arg = api.initiateUpload.mock.calls[0][0];
+    // plaintext tags ride in the (reversible) metadata
+    expect(decryptMetadata(arg.encryptedMetadata, keys.metadataKey).tags).toEqual(['Trip', 'beach']);
+    // searchable HMACs match encryptTagForSearch(tag, metadataKey, vaultId)
+    const expected = ['Trip', 'beach'].map((t) => encryptTagForSearch(t, keys.metadataKey, 'v1'));
+    expect(arg.encryptedTags.map((u: Uint8Array) => Array.from(u))).toEqual(expected.map((u) => Array.from(u)));
   });
 
   it('multipart path: parts uploaded in order, eTags collected, complete gets ordered parts', async () => {

--- a/packages/web/src/items/streamingUpload.ts
+++ b/packages/web/src/items/streamingUpload.ts
@@ -4,6 +4,7 @@ import {
   generateNoncePrefix,
   buildStreamHeader,
   encryptChunk,
+  encryptTagForSearch,
   DEFAULT_CHUNK_SIZE,
   STREAM_HEADER_SIZE,
   STREAM_VERSION,
@@ -65,9 +66,10 @@ export async function uploadFileStreaming(
   file: File,
   keys: VaultKeys,
   onProgress?: (fraction: number) => void,
-  opts?: { chunkSize?: number }, // ponytail: chunkSize is in the header anyway; override is test-only
+  opts?: { chunkSize?: number; tags?: string[] }, // chunkSize override is test-only
 ): Promise<void> {
   const chunkSize = opts?.chunkSize ?? DEFAULT_CHUNK_SIZE;
+  const tags = opts?.tags?.map((t) => t.trim()).filter(Boolean) ?? [];
   const plaintextSize = file.size;
   const partCount = Math.max(1, Math.ceil(plaintextSize / chunkSize));
   const sizeBytes = WRAPPED_DEK_SIZE + STREAM_HEADER_SIZE + plaintextSize + TAG_SIZE * partCount;
@@ -85,13 +87,19 @@ export async function uploadFileStreaming(
       size: plaintextSize,
       contentId,
       streamVersion: STREAM_VERSION,
+      ...(tags.length ? { tags } : {}),
     };
     const encryptedMetadata = await encryptMetadata(metadata, keys.metadataKey);
+
+    // Searchable form: one-way HMAC per tag (see encryptTagForSearch). Keyed on
+    // metadataKey + vaultId so the search path produces matching HMACs.
+    const encryptedTags = tags.map((t) => encryptTagForSearch(t, keys.metadataKey, keys.vaultId));
 
     const { itemId, uploadUrl, uploadId } = await initiateUpload({
       vaultId: keys.vaultId,
       encryptedMetadata,
       sizeBytes,
+      ...(encryptedTags.length ? { encryptedTags } : {}),
     });
 
     // Read + encrypt one chunk lazily; part 1 prepends wrappedDek + header.


### PR DESCRIPTION
## Phase B · Slice 3 — Collections + Tags (frontend)

Organize files into collections (named, many-to-many groups) and tag files (searchable + displayable). Completes web-app **task 7.4** — and with it, task 7 (auth + file management + streaming + collections/tags). **Frontend-only**, entirely on the existing Smithy SDK (no backend/contract change — verified `InitiateItemUploadInput.encryptedTags` already exists).

### Architecture
A single `view` union (`all | collection | tag`) in `Dashboard` selects the file-list source — `listItems`, `getCollection().items`, or `searchByTag().items`, all `ItemData[]` — so `FileList` renders any of them. `CollectionSidebar`/`TagSearch` emit `view` changes; nothing depends on a sibling component, only on the `View` type.

### What changed
- **`items/collectionMetadata.ts`** (new) — encrypt/decrypt `{ name }` with `metadataKey`.
- **`api/collections.ts`** (new) + `searchByTag` in `api/items.ts` — thin wrappers over the 8 generated commands.
- **`CollectionSidebar`** (new) — list (decrypt names) / create / select / delete; "All files" default.
- **`TagSearch`** (new) — encrypts the query → emits a tag view.
- **`FileList`** — multi-source load; tag chips from decrypted metadata; per-row "Add to collection".
- **`FileUpload` / `streamingUpload`** — tags input; dual-write (see below).
- **`Dashboard`** — owns `view` + `refreshKey`; lays out sidebar | upload + search + list.
- **`FileMetadata.tags?`** added.

### Tags: dual-write (zero-knowledge)
`encryptTagForSearch` is HMAC-SHA256 — deterministic and **one-way**. So at upload, tags are written two ways: readable `tags: string[]` in the file's encrypted metadata (shown as chips) **and** the one-way HMAC `encryptedTags` on the item (for search). Search re-derives the same HMAC (`encryptTagForSearch(query, metadataKey, vaultId)` → base64 → `searchByTag`), so matches happen server-side without the server ever seeing tag text.

### Tests
`npm --prefix packages/web test` → **87/87 green**; `tsc` + `vite build` clean. Covers: collection-name round-trip, all 8 API wrappers, tag dual-write at upload, sidebar list/create/select, multi-source list + chips + add-to-collection, tag-search query encryption, Dashboard wiring.

### Deferred (next backend slice)
**Edit tags on an existing file** — the backend only accepts `encrypted_tags` at item creation; changing them needs a new `UpdateItemTags`-style op. Out of this frontend-only slice, called out so it's planned. Also deferred: multi-tag AND/OR search, drag-and-drop, nested collections.

### Notes
A grep-window false alarm during planning suggested the TS client was missing `encryptedTags`; reading the generated source directly confirmed it's present (the field is the 4th member, just past a default `-A20` window). No regen needed.