### PR TITLE
ci(js-tests): use npm install, not npm ci (lock drifts vs regenerated client)

### DIFF
--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -48,11 +48,16 @@ jobs:
         run: ./gradlew smithyBuild
 
       # Single workspace install — covers @cortex/client, @cortex/encryption, @cortex/web.
+      # NOT `npm ci`: @cortex/client is gitignored and regenerated above by smithyBuild
+      # with floating `^` deps, so a fresh codegen resolves newer patch versions than the
+      # committed lock holds and `npm ci` hard-fails on the mismatch. `npm install`
+      # reconciles the lock against the just-generated client. Re-pin to `npm ci` only if
+      # the client is committed or its codegen emits exact versions.
       - name: Install dependencies
-        run: npm ci
+        run: npm install --no-audit --no-fund
 
       # Build generated/source packages whose compiled output @cortex/web imports
-      # (dist-*/dist), which a fresh `npm ci` does not produce.
+      # (dist-*/dist), which a fresh install does not produce.
       - name: Build client + encryption packages
         run: |
           npm run build:client


### PR DESCRIPTION
## Problem

`js-tests` is **red on every branch** — mainline's own push, all open PRs (#225, renovate/gradle), not any one feature. The failing step is **Install dependencies**, not the tests:

```
npm error `npm ci` can only install packages when your package.json and
package-lock.json ... are in sync.
npm error Invalid: lock file's @aws-sdk/core@3.974.22 does not satisfy @aws-sdk/core@3.974.23
npm error Missing: @tsconfig/node20@20.1.8 from lock file
npm error Invalid: lock file's @types/node@18.19.130 does not satisfy @types/node@20.19.43
...
```

## Root cause

The job order is **Build Smithy model → `npm ci`**. `smithyBuild` regenerates `packages/client` (which is **gitignored**, not committed) with floating `^` dependency ranges. A fresh codegen run resolves *newer* transitive patches than the committed `package-lock.json` was built against, so `npm ci`'s strict in-sync check hard-fails. This drifts further every time the registry ships a patch — which is why mainline and unrelated PRs are all red.

`npm ci` + a build-time-regenerated workspace package are fundamentally incompatible: the lock can never stay in sync with a package that's re-resolved on every run.

## Fix

Use `npm install --no-audit --no-fund`, which reconciles the lock against the just-generated client instead of rejecting it. The reproducibility `npm ci` would buy is already moot — the client itself is regenerated non-reproducibly each run.

A comment in the workflow records the why and the exit criteria (re-pin to `npm ci` only if `packages/client` is committed or its codegen emits exact versions).

## Scope
One line (+ rationale comment). Unblocks the whole repo's `js-tests`, including #225.